### PR TITLE
ENH: Close files between seeks/reads

### DIFF
--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -9,6 +9,7 @@
 
 from .indexed_gzip import (IndexedGzipFile,
                            SafeIndexedGzipFile,
+                           DroppingIndexedGzipFile,
                            NotCoveredError,
                            ZranError)
 

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -9,7 +9,6 @@
 
 from .indexed_gzip import (IndexedGzipFile,
                            SafeIndexedGzipFile,
-                           DroppingIndexedGzipFile,
                            NotCoveredError,
                            ZranError)
 

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -666,7 +666,11 @@ cdef class DroppingIndexedGzipFile(IndexedGzipFile):
             self.index.fd  = NULL
 
     def close(self):
-        super(DroppingIndexedGzipFile, self).close()
+        if self.filename is None:
+            super(DroppingIndexedGzipFile, self).close()
+        else:
+            zran.zran_free(&self.index)
+
         self.finalized = True
 
     @property

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -91,8 +91,17 @@ cdef class IndexedGzipFile:
     cdef object pyfid
     """A reference to the python file handle. """
 
+
     cdef object filename
+    """String containing path of file being indexed. Used to release and
+    reopen file handles between seeks and reads.
+    Set to ``None`` if file handle is passed.
+    """
+
     cdef bint finalized
+    """Flag which is set to ``True`` if the IndexedGzipFile has been closed.
+    Further operations will fail if ``True``.
+    """
 
 
     def __cinit__(self,

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -223,7 +223,11 @@ cdef class IndexedGzipFile:
             raise IOError('IndexedGzipFile is already closed')
 
         zran.zran_free(&self.index)
+
+        self.filename = None
+        self.pyfid = None
         self.finalized = True
+
         log.debug('{}.close()'.format(type(self).__name__))
 
 

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -88,10 +88,6 @@ cdef class IndexedGzipFile:
     """
 
 
-    cdef FILE *cfid
-    """A reference to the C file handle. """
-
-
     cdef object pyfid
     """A reference to the python file handle. """
 
@@ -156,13 +152,13 @@ cdef class IndexedGzipFile:
         else:
             self.pyfid = fid
 
-        self.cfid = fdopen(self.pyfid.fileno(), 'rb')
+        cfid = fdopen(self.pyfid.fileno(), 'rb')
 
         if self.auto_build: flags = zran.ZRAN_AUTO_BUILD
         else:               flags = 0
 
         if zran.zran_init(index=&self.index,
-                          fd=self.cfid,
+                          fd=cfid,
                           spacing=spacing,
                           window_size=window_size,
                           readbuf_size=readbuf_size,
@@ -183,14 +179,12 @@ cdef class IndexedGzipFile:
     def _acq_fh(self):
         if self.own_file:
             self.pyfid = open(self.filename, 'rb')
-            self.cfid = fdopen(self.pyfid.fileno(), 'rb')
-            self.index.fd = self.cfid
+            self.index.fd = fdopen(self.pyfid.fileno(), 'rb')
 
     def _rel_fh(self):
         if self.own_file:
             self.pyfid.close()
             self.pyfid = None
-            self.cfid  = NULL
             self.index.fd  = NULL
 
     def __init__(self, *args, **kwargs):

--- a/indexed_gzip/zran.pxd
+++ b/indexed_gzip/zran.pxd
@@ -12,7 +12,7 @@ from posix.types cimport off_t
 cdef extern from "zran.h":
 
     ctypedef struct zran_index_t:
-        pass
+        FILE *fd;
 
     ctypedef struct zran_point_t:
         pass


### PR DESCRIPTION
This is a proof of concept that #5 is possible. I can load and slice NIfTI a dataobj, and verify with `lsof` that the file is open during slicing and closed at rest.

I haven't benchmarked to see what kind of penalty this will impose. If it's low and you think it's a good idea to directly modify `IndexedGzipFile`, I can do that, otherwise we'll want to fill in the docs (and probably come up with better names).

And it might be a good idea to track the file mtime and raise an error if the file looks to have changed underneath us.