### PR TITLE
Import/export functionality

### DIFF
--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -661,12 +661,12 @@ cdef class IndexedGzipFile:
         pass
 
     def export_index(self, filename=None, fileobj=None):
-        '''Export index data to the given file. Either ``filename`` or
+        """Export index data to the given file. Either ``filename`` or
         ``fileobj`` should be specified, but not both. ``fileobj`` should be
         opened in 'wb' mode.
 
         :arg filename: Name of the file.
-        :arg fileobj:  Open file handle.'''
+        :arg fileobj:  Open file handle."""
 
         if filename is None and fileobj is None:
             raise ValueError('One of filename or fileobj must be specified')
@@ -681,7 +681,7 @@ cdef class IndexedGzipFile:
 
         else:
             close_file = False
-            if fileobj.mode not in 'wb':
+            if fileobj.mode is not 'wb':
                 raise ValueError(
                     'File should be opened write-only binary mode.')
 
@@ -701,12 +701,12 @@ cdef class IndexedGzipFile:
             fileobj))
 
     def import_index(self, filename=None, fileobj=None):
-        '''Import index data from the given file. Either ``filename`` or
+        """Import index data from the given file. Either ``filename`` or
         ``fileobj`` should be specified, but not both. ``fileobj`` should be
         opened in 'rb' mode.
 
         :arg filename: Name of the file.
-        :arg fileobj:  Open file handle.'''
+        :arg fileobj:  Open file handle."""
 
         if filename is None and fileobj is None:
             raise ValueError('One of filename or fileobj must be specified')
@@ -721,7 +721,7 @@ cdef class IndexedGzipFile:
 
         else:
             close_file = False
-            if fileobj.mode not in 'rb':
+            if fileobj.mode is not 'rb':
                 raise ValueError(
                     'File should be opened read-only binary mode.')
 

--- a/indexed_gzip/tests/test_zran.py
+++ b/indexed_gzip/tests/test_zran.py
@@ -35,3 +35,4 @@ if not sys.platform.startswith("win"):
     def test_read_all_sequential(   testfile, nelems):                         ctest_zran.test_read_all_sequential(   testfile, nelems)
     def test_build_then_read(       testfile, nelems, seed, use_mmap):         ctest_zran.test_build_then_read(       testfile, nelems, seed, use_mmap)
     def test_readbuf_spacing_sizes( testfile, nelems, niters, seed):           ctest_zran.test_readbuf_spacing_sizes( testfile, nelems, niters, seed)
+    def test_export_then_import(    testfile):                                 ctest_zran.test_export_then_import(    testfile)

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -2397,7 +2397,7 @@ int zran_export_index(zran_index_t *index,
      * consistent with gzip library.
      */
 
-    /* Used to check return value of fwrite calls. */
+    /* Used for checking return value of fwrite calls. */
     size_t f_ret;
 
     /* Used for iterating over elements of zran_index_t.list. */
@@ -2526,7 +2526,10 @@ int zran_export_index(zran_index_t *index,
      * It is important to flush written file when done, since underlying file
      * descriptor can be closed by Python code before having a chance to flush.
      */
-    fflush(fd);
+    f_ret = fflush(fd);
+
+    if (ferror(fd)) goto fail;
+    if (f_ret != 0) goto fail;
 
     return ZRAN_EXPORT_OK;
 
@@ -2542,7 +2545,7 @@ fail:
 int zran_import_index(zran_index_t *index,
                       FILE *fd) {
 
-    /* Used to check return value of fread calls. */
+    /* Used for checking return value of fread calls. */
     size_t f_ret;
 
     /* Return value of function if a failure happens. */

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -2564,6 +2564,9 @@ int zran_import_index(zran_index_t *index,
     uint32_t      npoints;
     zran_point_t *new_list = NULL;
 
+    /* Check if file is read only. */
+    if (!is_readonly(fd)) goto fail;
+
     /* Read compressed size, and check for file errors and EOF. */
     f_ret = fread(&compressed_size, sizeof(compressed_size), 1, fd);
 

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -370,8 +370,6 @@ enum {
  *   - ZRAN_IMPORT_MEMORY_ERROR to indicate failure to allocate memory for new
  *     index. This typically result from out-of-memory.
  *
- *   - ZRAN_EXPORT_WRITE_ERROR to indicate an error from writing to underlying
- *     file.
  */
 int zran_import_index(
   zran_index_t  *index, /* The index                  */

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -323,8 +323,8 @@ enum {
  *     file.
  */
 int zran_export_index(
-  zran_index_t  *index; /* The index                  */
-  FILE          *fd;    /* Open handle to export file */
+  zran_index_t  *index, /* The index                  */
+  FILE          *fd     /* Open handle to export file */
 );
 
 /* Return codes for zran_import_index. */
@@ -339,10 +339,14 @@ enum {
 };
 
 /*
- * Import current index from the given file. Existing index will be deleted.
- * Updating an index file directly is not supported currently. To update an
- * index file first import it, create new checkpoints, and then export it
- * again.
+ * Import current index from the given file.  index must have been initialized
+ * by zran_init function before calling this function, as it is not supported
+ * importing into an uninitialised zran_index_t struct. Existing index will be
+ * overwritten including spacing and window_size values, whereas values of
+ * readbuf_size and flags will be kept.
+ *
+ * Updating an index file is not supported currently. To update an index file,
+ * first import it, create new checkpoints, and then export it again.
  *
  * See zran_export_index for exporting.
  *
@@ -370,8 +374,8 @@ enum {
  *     file.
  */
 int zran_import_index(
-  zran_index_t  *index; /* The index                  */
-  FILE          *fd;    /* Open handle to import file */
+  zran_index_t  *index, /* The index                  */
+  FILE          *fd     /* Open handle to import file */
 );
 
 #endif /* __ZRAN_H__ */

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -304,4 +304,74 @@ int64_t zran_read(
   uint64_t       len    /* Number of bytes to read   */
 );
 
+/* Return codes for zran_export_index. */
+enum {
+    ZRAN_EXPORT_OK          =  0,
+    ZRAN_EXPORT_WRITE_ERROR = -1
+};
+
+/*
+ * Export current index data to given file. This exported file later can be
+ * used to rebuild index without needing to going through the file again.
+ *
+ * See zran_import_index for importing.
+ *
+ * Returns:
+ *   - ZRAN_EXPORT_OK for success.
+ *
+ *   - ZRAN_EXPORT_WRITE_ERROR to indicate an error from writing to underlying
+ *     file.
+ */
+int zran_export_index(
+  zran_index_t  *index; /* The index                  */
+  FILE          *fd;    /* Open handle to export file */
+);
+
+/* Return codes for zran_import_index. */
+enum {
+    ZRAN_IMPORT_OK           =  0,
+    ZRAN_IMPORT_FAIL         = -1,
+    ZRAN_IMPORT_EOF          = -2,
+    ZRAN_IMPORT_READ_ERROR   = -3,
+    ZRAN_IMPORT_OVERFLOW     = -4,
+    ZRAN_IMPORT_INCONSISTENT = -5,
+    ZRAN_IMPORT_MEMORY_ERROR = -6
+};
+
+/*
+ * Import current index from the given file. Existing index will be deleted.
+ * Updating an index file directly is not supported currently. To update an
+ * index file first import it, create new checkpoints, and then export it
+ * again.
+ *
+ * See zran_export_index for exporting.
+ *
+ * Returns:
+ *   - ZRAN_IMPORT_OK for success.
+ *
+ *   - ZRAN_IMPORT_FAIL general errors.
+ *
+ *   - ZRAN_IMPORT_EOF to indicate unexpected end-of-file.
+ *
+ *   - ZRAN_IMPORT_READ_ERROR to indicate error while reading file.
+ *
+ *   - ZRAN_IMPORT_OVERFLOW to indicate overflow while reading compressed and
+ *     uncompressed size attributes. This shouldn't be a problem for x64
+ *     processors.
+ *
+ *   - ZRAN_IMPORT_INCONSISTENT to indicate compressed size, or uncompressed
+ *     size if known,   of the index file is inconsistent with the loaded
+ *     compressed file.
+ *
+ *   - ZRAN_IMPORT_MEMORY_ERROR to indicate failure to allocate memory for new
+ *     index. This typically result from out-of-memory.
+ *
+ *   - ZRAN_EXPORT_WRITE_ERROR to indicate an error from writing to underlying
+ *     file.
+ */
+int zran_import_index(
+  zran_index_t  *index; /* The index                  */
+  FILE          *fd;    /* Open handle to import file */
+);
+
 #endif /* __ZRAN_H__ */

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -304,6 +304,9 @@ int64_t zran_read(
   uint64_t       len    /* Number of bytes to read   */
 );
 
+/* Magic bytes for exported index type. Value is defined in zran.c. */
+extern const char zran_magic_bytes[];
+
 /* Return codes for zran_export_index. */
 enum {
     ZRAN_EXPORT_OK          =  0,
@@ -329,13 +332,14 @@ int zran_export_index(
 
 /* Return codes for zran_import_index. */
 enum {
-    ZRAN_IMPORT_OK           =  0,
-    ZRAN_IMPORT_FAIL         = -1,
-    ZRAN_IMPORT_EOF          = -2,
-    ZRAN_IMPORT_READ_ERROR   = -3,
-    ZRAN_IMPORT_OVERFLOW     = -4,
-    ZRAN_IMPORT_INCONSISTENT = -5,
-    ZRAN_IMPORT_MEMORY_ERROR = -6
+    ZRAN_IMPORT_OK             =  0,
+    ZRAN_IMPORT_FAIL           = -1,
+    ZRAN_IMPORT_EOF            = -2,
+    ZRAN_IMPORT_READ_ERROR     = -3,
+    ZRAN_IMPORT_OVERFLOW       = -4,
+    ZRAN_IMPORT_INCONSISTENT   = -5,
+    ZRAN_IMPORT_MEMORY_ERROR   = -6,
+    ZRAN_IMPORT_UNKNOWN_FORMAT = -7
 };
 
 /*
@@ -370,6 +374,7 @@ enum {
  *   - ZRAN_IMPORT_MEMORY_ERROR to indicate failure to allocate memory for new
  *     index. This typically result from out-of-memory.
  *
+ *   - ZRAN_IMPORT_UNKNOWN_FORMAT to indicate given file is of unknown format.
  */
 int zran_import_index(
   zran_index_t  *index, /* The index                  */

--- a/indexed_gzip/zran.pxd
+++ b/indexed_gzip/zran.pxd
@@ -12,10 +12,19 @@ from posix.types cimport off_t
 cdef extern from "zran.h":
 
     ctypedef struct zran_index_t:
-        FILE *fd;
+        FILE         *fd;
+        size_t        compressed_size;
+        size_t        uncompressed_size;
+        uint32_t      spacing;
+        uint32_t      window_size;
+        uint32_t      npoints;
+        zran_point_t *list;
 
     ctypedef struct zran_point_t:
-        pass
+        uint64_t  cmp_offset;
+        uint64_t  uncmp_offset;
+        uint8_t   bits;
+        uint8_t  *data;
 
     enum:
         ZRAN_AUTO_BUILD       =  1,

--- a/indexed_gzip/zran.pxd
+++ b/indexed_gzip/zran.pxd
@@ -40,13 +40,14 @@ cdef extern from "zran.h":
         ZRAN_EXPORT_OK          =  0,
         ZRAN_EXPORT_WRITE_ERROR = -1,
 
-        ZRAN_IMPORT_OK           =  0,
-        ZRAN_IMPORT_FAIL         = -1,
-        ZRAN_IMPORT_EOF          = -2,
-        ZRAN_IMPORT_READ_ERROR   = -3,
-        ZRAN_IMPORT_OVERFLOW     = -4,
-        ZRAN_IMPORT_INCONSISTENT = -5,
-        ZRAN_IMPORT_MEMORY_ERROR = -6
+        ZRAN_IMPORT_OK             =  0,
+        ZRAN_IMPORT_FAIL           = -1,
+        ZRAN_IMPORT_EOF            = -2,
+        ZRAN_IMPORT_READ_ERROR     = -3,
+        ZRAN_IMPORT_OVERFLOW       = -4,
+        ZRAN_IMPORT_INCONSISTENT   = -5,
+        ZRAN_IMPORT_MEMORY_ERROR   = -6,
+        ZRAN_IMPORT_UNKNOWN_FORMAT = -7
 
     bint zran_init(zran_index_t *index,
                    FILE         *fd,

--- a/indexed_gzip/zran.pxd
+++ b/indexed_gzip/zran.pxd
@@ -28,6 +28,17 @@ cdef extern from "zran.h":
         ZRAN_READ_EOF         = -2,
         ZRAN_READ_FAIL        = -3,
 
+        ZRAN_EXPORT_OK          =  0,
+        ZRAN_EXPORT_WRITE_ERROR = -1,
+
+        ZRAN_IMPORT_OK           =  0,
+        ZRAN_IMPORT_FAIL         = -1,
+        ZRAN_IMPORT_EOF          = -2,
+        ZRAN_IMPORT_READ_ERROR   = -3,
+        ZRAN_IMPORT_OVERFLOW     = -4,
+        ZRAN_IMPORT_INCONSISTENT = -5,
+        ZRAN_IMPORT_MEMORY_ERROR = -6
+
     bint zran_init(zran_index_t *index,
                    FILE         *fd,
                    uint32_t      spacing,
@@ -51,3 +62,9 @@ cdef extern from "zran.h":
     int64_t zran_read(zran_index_t *index,
                       void         *buf,
                       uint64_t      len) nogil;
+
+    int zran_export_index(zran_index_t *index,
+                          FILE         *fd);
+
+    int zran_import_index(zran_index_t *index,
+                          FILE         *fd);


### PR DESCRIPTION
Hi!

I've implemented basic index export and import functionality (#7). There are still some minor stuff to do. I believe some feedback before moving on would be very helpful.

TODO list:

- [x] **Interface to python:** An interface to both import and export functions will be added for python library.

- [x] **Bundle offset fields together in exported file:** I realized dumping other fields (compressed/uncompressed offset/bit) of all checkpoints before dumping data fields is a better idea. This keeps offsets together so that a user can read all offsets in one disk I/O, and then seek to the checkpoint data on demand requiring just one more disk I/O. Currently, user is required to seek different offsets for each offset look up while searching data.

- [x] **Magic bytes and version header:** Adding magic bytes and version header may protect exported files being broken with future changes in library. How about adding ASCII 'GZIDX' as magic bytes for export files?

Any feedback or suggestions are welcomed!

Thanks!