### PR TITLE
BF: Failure when file size is a multiple of read buffer size

### DIFF
--- a/.ci/run_32bit_test.sh
+++ b/.ci/run_32bit_test.sh
@@ -31,7 +31,7 @@ fi
 
 export PATH=/mypython/bin:$PATH
 
-pip install cython numpy pytest coverage pytest-cov
+pip install --upgrade cython numpy pytest coverage pytest-cov
 
 cd /indexed_gzip
 python setup.py develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ env:
   - TEST_SUITE=indexed_gzip_test EXTRA_ARGS="--use_mmap --concat"  NITERS=1000 NELEMS=805306368
   - TEST_SUITE=32bittest
 
-install: "pip install cython numpy pytest coverage pytest-cov"
+install: "pip install --upgrade cython numpy pytest coverage pytest-cov"
 
 script:
   - .ci/run_tests.sh

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include                        LICENSE
+include                        README.md
 include                        conftest.py
 recursive-include indexed_gzip *.py
 recursive-include indexed_gzip *.pyx

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,7 @@ install:
   - conda create  --yes -n test_env python=%PYTHON_VERSION%
   - activate test_env
   - conda install --yes cython numpy zlib six pytest coverage pytest-cov
+  - conda update --yes pytest
   - set ZLIB_HOME=%CONDA_PREFIX%\\Library
   - python setup.py develop
 

--- a/conftest.py
+++ b/conftest.py
@@ -80,17 +80,15 @@ def seed(request):
 
 
 @pytest.fixture
-def testfile(request):
+def testfile(request, nelems, concat):
 
     filename = request.config.getoption('--testfile')
-    _nelems  = nelems(request)
-    _concat  = concat(request)
 
     if filename is None:
         filename = op.join(os.getcwd(),
-                           'ctest_zran_{}_{}.gz'.format(_nelems, _concat))
+                           'ctest_zran_{}_{}.gz'.format(nelems, concat))
 
     if not op.exists(filename):
-        gen_test_data(filename, _nelems, _concat)
+        gen_test_data(filename, nelems, concat)
 
     return filename

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -15,6 +15,7 @@ import               time
 import               gzip
 import               random
 import               tempfile
+import               shutil
 import               hashlib
 import               textwrap
 
@@ -31,6 +32,17 @@ from . import testdir
 from libc.stdio cimport (SEEK_SET,
                          SEEK_CUR,
                          SEEK_END)
+
+
+def tempdir():
+    testdir = tempfile.mkdtemp(dir=root)
+    prevdir = os.getcwd()
+    try:
+        os.chdir(testdir)
+        yield testdir
+
+    finally:
+        shutil.rmtree(testdir)
 
 
 def read_element(gzf, element, seek=True):
@@ -674,7 +686,7 @@ def test_size_multiple_of_readbuf():
 
     fname = 'test.gz'
 
-    with tempfile.TemporaryDirectory():
+    with tempdir():
 
         data = np.random.randint(1, 1000, 10000, dtype=np.uint32)
 

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -18,6 +18,7 @@ import               tempfile
 import               shutil
 import               hashlib
 import               textwrap
+import               contextlib
 
 import numpy as np
 
@@ -34,6 +35,7 @@ from libc.stdio cimport (SEEK_SET,
                          SEEK_END)
 
 
+@contextlib.contextmanager
 def tempdir():
     testdir = tempfile.mkdtemp()
     prevdir = os.getcwd()

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -35,7 +35,7 @@ from libc.stdio cimport (SEEK_SET,
 
 
 def tempdir():
-    testdir = tempfile.mkdtemp(dir=root)
+    testdir = tempfile.mkdtemp()
     prevdir = os.getcwd()
     try:
         os.chdir(testdir)

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -332,7 +332,7 @@ def test_seek(concat):
                 f.seek(100, SEEK_END)
 
         for data, expected in results:
-            val = np.fromstring(data, dtype=np.uint64)
+            val = np.frombuffer(data, dtype=np.uint64)
             assert val == expected
 
 
@@ -398,7 +398,7 @@ def test_pread():
             for i in range(20):
                 off  = np.random.randint(0, nelems, 1)[0]
                 data = f.pread(8, off * 8)
-                val  = np.fromstring(data, dtype=np.uint64)
+                val  = np.frombuffer(data, dtype=np.uint64)
                 assert val[0] == off
 
 
@@ -624,14 +624,14 @@ def test_import_export_index():
         # Check that index file works via __init__
         with igzip._IndexedGzipFile(fname, index_file=idxfname) as f:
             f.seek(65535 * 8)
-            val = np.fromstring(f.read(8), dtype=np.uint64)
+            val = np.frombuffer(f.read(8), dtype=np.uint64)
             assert val[0] == 65535
 
         # Check that index file works via import_index
         with igzip._IndexedGzipFile(fname) as f:
             f.import_index(idxfname)
             f.seek(65535 * 8)
-            val = np.fromstring(f.read(8), dtype=np.uint64)
+            val = np.frombuffer(f.read(8), dtype=np.uint64)
             assert val[0] == 65535
 
         # generate an index file from open file handle
@@ -659,7 +659,7 @@ def test_import_export_index():
             with open(idxfname, 'rb') as idxf:
                 f.import_index(fileobj=idxf)
             f.seek(65535 * 8)
-            val = np.fromstring(f.read(8), dtype=np.uint64)
+            val = np.frombuffer(f.read(8), dtype=np.uint64)
             assert val[0] == 65535
 
 

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -45,6 +45,7 @@ def tempdir():
 
     finally:
         shutil.rmtree(testdir)
+        os.chdir(prevdir)
 
 
 def read_element(gzf, element, seek=True):

--- a/indexed_gzip/tests/test_indexed_gzip.py
+++ b/indexed_gzip/tests/test_indexed_gzip.py
@@ -132,3 +132,6 @@ def test_import_export_index():
 
 def test_wrapper_class():
     ctest_indexed_gzip.test_wrapper_class()
+
+def test_size_multiple_of_readbuf():
+    ctest_indexed_gzip.test_size_multiple_of_readbuf()

--- a/indexed_gzip/tests/test_indexed_gzip_threading.py
+++ b/indexed_gzip/tests/test_indexed_gzip_threading.py
@@ -23,16 +23,16 @@ from . import check_data_valid
 pytestmark = pytest.mark.indexed_gzip_test
 
 
-def test_IndexedGzipFile_open_close(testfile):
+def test_IndexedGzipFile_open_close(testfile, nelems, concat):
     _test_IndexedGzipFile_open_close(testfile, False)
 
-def test_IndexedGzipFile_open_close_drop_handles(testfile):
+def test_IndexedGzipFile_open_close_drop_handles(testfile, nelems, concat):
     _test_IndexedGzipFile_open_close(testfile, True)
 
-def test_IndexedGzipFile_pread_threaded(testfile, nelems):
+def test_IndexedGzipFile_pread_threaded(testfile, nelems, concat):
     _test_IndexedGzipFile_pread_threaded(testfile, nelems, False)
 
-def test_IndexedGzipFile_pread_threaded_drop_handles(testfile, nelems):
+def test_IndexedGzipFile_pread_threaded_drop_handles(testfile, nelems, concat):
     _test_IndexedGzipFile_pread_threaded(testfile, nelems, True)
 
 

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,10 @@ class Clean(Command):
                 except OSError: pass
 
 
+with open(op.join(op.dirname(__file__), 'README.md'), 'rt') as f:
+    readme = f.read().strip()
+
+
 # Platform information
 python2 = sys.version_info[0] == 2
 noc99   = python2 or (sys.version_info[0] == 3 and sys.version_info[1] <= 4)
@@ -199,6 +203,7 @@ setup(
     author='Paul McCarthy',
     author_email='pauldmccarthy@gmail.com',
     description='Fast random access of gzip files in Python',
+    long_description=readme,
     url='https://github.com/pauldmccarthy/indexed_gzip',
     license='zlib',
 


### PR DESCRIPTION
Closes #14.

The `zran_inflate` function in `zran.c` was assuming that `feof` would return non-zero when there was no more compressed data to be read from the file. But `feof` only returns non-zero when an attempt is made to read *past* the end of a file - if a read is made up to, but not beyond, the final byte, `feof` will still return 0.

This had the effect that `seek` and `read` would consistently fail for files which had a size which was a multiple of the read buffer size.

The code has been updated to use `ftell` to check the current file position, rather than relying on `feof`.
