### PR TITLE
Win64: fix tell() returning int32

### DIFF
--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -2104,7 +2104,7 @@ eof:
 }
 
 /* Return the current seek position in the uncompressed data stream. */
-long zran_tell(zran_index_t *index) {
+uint64_t zran_tell(zran_index_t *index) {
 
     return index->uncmp_seek_offset;
 }

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -270,7 +270,7 @@ int zran_seek(
  * Returns the current seek location in the uncompressed data stream
  * (just returns zran_index_t.uncmp_seek_offset).
  */
-long zran_tell(
+uint64_t zran_tell(
   zran_index_t *index /* The index */
 );
 

--- a/indexed_gzip/zran.pxd
+++ b/indexed_gzip/zran.pxd
@@ -62,7 +62,7 @@ cdef extern from "zran.h":
                           uint64_t      from_,
                           uint64_t      until) nogil;
 
-    long zran_tell(zran_index_t *index);
+    uint64_t zran_tell(zran_index_t *index);
 
     int zran_seek(zran_index_t  *index,
                   int64_t        offset,


### PR DESCRIPTION
Related to https://github.com/pauldmccarthy/indexed_gzip/issues/29