### PR TITLE
WIP: ENH/serialisation

### DIFF
--- a/.ci/run_32bit_test.sh
+++ b/.ci/run_32bit_test.sh
@@ -35,5 +35,5 @@ pip install --upgrade cython numpy pytest coverage pytest-cov
 
 cd /indexed_gzip
 python setup.py develop
-pytest -v -s --niters 500
-pytest -v -s --niters 500 --concat
+pytest --no-cov -v -s --niters 500
+pytest --no-cov -v -s --niters 500 --concat

--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -30,5 +30,5 @@ if [ "$TEST_SUITE" == "32bittest" ]; then
 else
     export INDEXED_GZIP_TESTING=1
     python setup.py develop;
-    pytest -v -s -m "$TEST_SUITE" -k "$TEST_PATTERN" --nelems "$NELEMS" --niters "$NITERS" $EXTRA_ARGS;
+    pytest --no-cov -v -s -m "$TEST_SUITE" -k "$TEST_PATTERN" --nelems "$NELEMS" --niters "$NITERS" $EXTRA_ARGS;
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   the default setting of `drop_handles=True` (#28, 31).
 * Changed the return type of `zran_tell` from `long` to `uint64_t`, because the
   former is not guaranteed to be 64 bit (#29, #30).
-* Changes to the `zran_index_t` struct definition to support older/32 bit
-  environments.
+* Changed the `zran_index_t.compressed_size` and `uncompressed_size` fields from
+  `size_t` to `uint64_t` because the former is not guaranteed to be 64 bit.
 
 
 ## 1.0.0 (February 21st 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # `indexed_gzip` changelog
 
 
-## 1.1.0 (April 18th 2020)
+## 1.1.0 (April 19th 2020)
 
 
 * `IndexedGzipFile` objects are now picklable, as long as they are created with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # `indexed_gzip` changelog
 
 
-## 1.1.0 (April 19th 2020)
+## 1.1.0 (April 20th 2020)
 
 
 * `IndexedGzipFile` objects are now picklable, as long as they are created with
   the default setting of `drop_handles=True` (#28, 31).
 * Changed the return type of `zran_tell` from `long` to `uint64_t`, because the
   former is not guaranteed to be 64 bit (#29, #30).
+* Changes to the `zran_index_t` struct definition to support older/32 bit
+  environments.
 
 
 ## 1.0.0 (February 21st 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # `indexed_gzip` changelog
 
 
-## 1.1.0 (April 17th 2020)
+## 1.1.0 (April 18th 2020)
 
 
 * `IndexedGzipFile` objects are now picklable, as long as they are created with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # `indexed_gzip` changelog
 
 
+## 1.1.0 (April 15th 2020)
+
+
+* Changed the return type of `zran_tell` from `long` to `uint64_t`, because the
+  former is not guaranteed to be 64 bit (#29, #30).
+
+
 ## 1.0.0 (February 21st 2020)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # `indexed_gzip` changelog
 
 
-## 1.1.0 (April 15th 2020)
+## 1.1.0 (April 17th 2020)
 
 
+* `IndexedGzipFile` objects are now picklable, as long as they are created with
+  the default setting of `drop_handles=True` (#28, 31).
 * Changed the return type of `zran_tell` from `long` to `uint64_t`, because the
   former is not guaranteed to be 64 bit (#29, #30).
 

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ Many thanks to the following contributors (listed chronologically):
  - Martin Craig (@mcraig-ibme): porting `indexed_gzip` to Windows (#3)
  - Chris Markiewicz (@effigies): Option to drop file handles (#6)
  - Omer Ozarslan (@ozars): Index import/export (#8)
-
+ - @DarioDaF: Windows overflow bug (#30)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,20 @@ only have to decompress (on average) 512KB of data to read from any location
 in the file.
 
 
+## Intended use
+
+
+You may find `indexed_gzip` useful if you need to read from large GZIP files.
+A major advantage of `indexed_gzip` is that it will work with any GZIP file.
+However, if you have control over the creation of your GZIP files, you may
+wish to consider some alternatives:
+
+ * [`mgzip`](https://github.com/vinlyx/mgzip/) provides an accelerated
+   GZIP compression and decompression library.
+ * Compression formats other than GZIP, such as `bzip2` and `xz`, have better
+   support for random access.
+
+
 ## Installation
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,5 +70,3 @@ install:
 test_script:
   - pytest -v -s -m indexed_gzip_test          --niters 250
   - pytest -v -s -m indexed_gzip_test --concat --niters 250
-  # test >4GB files
-  - pytest -v -s -m indexed_gzip_test           --niters 250 --nelems 805306368 -k "test_seek_and_read"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,3 +70,5 @@ install:
 test_script:
   - pytest -v -s -m indexed_gzip_test          --niters 250
   - pytest -v -s -m indexed_gzip_test --concat --niters 250
+  # test >4GB files
+  - TEST_SUITE=zran_test pytest -v -s -m zran_test --use_mmap --niters 1000 --nelems 805306368 -k "not test_readbuf_spacing_sizes and not test_seek_then_read_block"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,4 +71,4 @@ test_script:
   - pytest -v -s -m indexed_gzip_test          --niters 250
   - pytest -v -s -m indexed_gzip_test --concat --niters 250
   # test >4GB files
-  - pytest -v -s -m indexed_gzip_test --use_mmap --niters 1000 --nelems 805306368
+  - pytest -v -s -m indexed_gzip_test           --niters 250 --nelems 805306368 -k "test_seek_and_read"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,4 +71,4 @@ test_script:
   - pytest -v -s -m indexed_gzip_test          --niters 250
   - pytest -v -s -m indexed_gzip_test --concat --niters 250
   # test >4GB files
-  - pytest -v -s -m zran_test --use_mmap --niters 1000 --nelems 805306368 -k "not test_readbuf_spacing_sizes and not test_seek_then_read_block"
+  - pytest -v -s -m indexed_gzip_test --use_mmap --niters 1000 --nelems 805306368

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -71,4 +71,4 @@ test_script:
   - pytest -v -s -m indexed_gzip_test          --niters 250
   - pytest -v -s -m indexed_gzip_test --concat --niters 250
   # test >4GB files
-  - TEST_SUITE=zran_test pytest -v -s -m zran_test --use_mmap --niters 1000 --nelems 805306368 -k "not test_readbuf_spacing_sizes and not test_seek_then_read_block"
+  - pytest -v -s -m zran_test --use_mmap --niters 1000 --nelems 805306368 -k "not test_readbuf_spacing_sizes and not test_seek_then_read_block"

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -14,4 +14,4 @@ from .indexed_gzip import (_IndexedGzipFile,     # noqa
                            ZranError)
 
 
-__version__ = '1.0.0'
+__version__ = '1.1.0'

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -119,17 +119,17 @@ cdef class _IndexedGzipFile:
     """
 
 
-    def __cinit__(self,
-                  filename=None,
-                  fileobj=None,
-                  mode=None,
-                  auto_build=True,
-                  spacing=4194304,
-                  window_size=32768,
-                  readbuf_size=1048576,
-                  readall_buf_size=16777216,
-                  drop_handles=True,
-                  index_file=None):
+    def __init__(self,
+                 filename=None,
+                 fileobj=None,
+                 mode=None,
+                 auto_build=True,
+                 spacing=4194304,
+                 window_size=32768,
+                 readbuf_size=1048576,
+                 readall_buf_size=16777216,
+                 drop_handles=True,
+                 index_file=None):
         """Create an ``_IndexedGzipFile``. The file may be specified either
         with an open file handle (``fileobj``), or with a ``filename``. If the
         former, the file must have been opened in ``'rb'`` mode.
@@ -231,13 +231,6 @@ cdef class _IndexedGzipFile:
 
         if index_file is not None:
             self.import_index(index_file)
-
-
-    def __init__(self, *args, **kwargs):
-        """This method does nothing. It is here to make sub-classing
-        ``_IndexedGzipFile`` easier.
-        """
-        pass
 
 
     def __file_handle(self):

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -19,6 +19,7 @@ from libc.stdio     cimport (SEEK_SET,
                              fclose)
 
 from libc.stdint    cimport (uint8_t,
+                             uint32_t,
                              uint64_t,
                              int64_t)
 
@@ -82,14 +83,29 @@ cdef class _IndexedGzipFile:
     """A reference to the ``zran_index`` struct. """
 
 
-    cdef readonly bint auto_build
-    """Flag which is set to ``True`` if the file index is built automatically
-    on seeks/reads.
+    cdef readonly uint32_t spacing
+    """Number of bytes between index seek points. """
+
+
+    cdef readonly uint32_t window_size
+    """Number of bytes of uncompressed data stored with each seek point."""
+
+
+    cdef readonly uint32_t readbuf_size
+    """Size of buffer in bytes for storing compressed data read in from the
+    file.
     """
 
 
     cdef readonly unsigned int readall_buf_size
-    """Used by meth:`read` as the read buffer size."""
+    """Size of buffer in bytes used by :meth:`read` when reading until EOF.
+    """
+
+
+    cdef readonly bint auto_build
+    """Flag which is set to ``True`` if the file index is built automatically
+    on seeks/reads.
+    """
 
 
     cdef readonly object filename
@@ -199,8 +215,12 @@ cdef class _IndexedGzipFile:
                 fileobj = open(filename, mode)
             fd = fdopen(fileobj.fileno(), 'rb')
 
-        self.auto_build       = auto_build
+
+        self.spacing          = spacing
+        self.window_size      = window_size
+        self.readbuf_size     = readbuf_size
         self.readall_buf_size = readall_buf_size
+        self.auto_build       = auto_build
         self.drop_handles     = drop_handles
         self.filename         = filename
         self.own_file         = own_file

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -902,7 +902,7 @@ class IndexedGzipFile(io.BufferedReader):
         """Seeks to ``offset``, then reads and returns up to ``nbytes``.
         The calls to seek and read are protected by a ``threading.RLock``.
         """
-        with self.__fileLock:
+        with self.__file_lock:
             self.seek(offset)
             return self.read(nbytes)
 

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -838,5 +838,5 @@ def test_32bit_overflow(niters, seed):
 
                 ft = f.tell()
 
-                assert ft      == (testval + 1) * 8
+                assert ft      == int(testval + 1) * 8
                 assert readval == 1

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -777,7 +777,7 @@ def test_picklable():
 def _mpfunc(gzf, size, offset):
     gzf.seek(offset)
     bytes = gzf.read(size)
-    val = np.ndarray(1, np.uint32, buffer=bytes)
+    val = np.ndarray(int(size / 4), np.uint32, buffer=bytes)
     return val.sum()
 
 
@@ -792,7 +792,7 @@ def test_multiproc_serialise():
 
         gzf = igzip.IndexedGzipFile(fname)
 
-        size    = len(data) / 15
+        size    = len(data) / 16
         offsets = np.arange(0, len(data), size)
         func    = ft.partial(_mpfunc, gzf, size * 4)
 

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -804,8 +804,8 @@ def test_multiproc_serialise():
 
         pool = mp.Pool(8)
         results = pool.map(func, offsets * 4)
-        pool.join()
         pool.close()
+        pool.join()
         gzf.close()
         del gzf
         del pool

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -796,8 +796,9 @@ def test_multiproc_serialise():
         offsets = np.arange(0, len(data), size)
         func    = ft.partial(_mpfunc, gzf, size * 4)
 
-        with mp.Pool(8) as pool:
-            results = pool.map(func, offsets * 4)
+        pool = mp.Pool(8)
+        results = pool.map(func, offsets * 4)
+        pool.close()
 
         expected = [data[off:off+size].sum() for off in offsets]
 

--- a/indexed_gzip/tests/test_indexed_gzip.py
+++ b/indexed_gzip/tests/test_indexed_gzip.py
@@ -138,3 +138,6 @@ def test_size_multiple_of_readbuf():
 
 def test_picklable():
     ctest_indexed_gzip.test_picklable()
+
+def test_multiproc_serialise():
+    ctest_indexed_gzip.test_multiproc_serialise()

--- a/indexed_gzip/tests/test_indexed_gzip.py
+++ b/indexed_gzip/tests/test_indexed_gzip.py
@@ -141,3 +141,6 @@ def test_picklable():
 
 def test_multiproc_serialise():
     ctest_indexed_gzip.test_multiproc_serialise()
+
+def test_32bit_overflow(niters, seed):
+    ctest_indexed_gzip.test_32bit_overflow(niters, seed)

--- a/indexed_gzip/tests/test_indexed_gzip.py
+++ b/indexed_gzip/tests/test_indexed_gzip.py
@@ -135,3 +135,6 @@ def test_wrapper_class():
 
 def test_size_multiple_of_readbuf():
     ctest_indexed_gzip.test_size_multiple_of_readbuf()
+
+def test_picklable():
+    ctest_indexed_gzip.test_picklable()

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -46,13 +46,13 @@ struct _zran_index {
      * Size of the compressed file. This
      * is calculated in zran_init.
      */
-    size_t        compressed_size;
+    uint64_t      compressed_size;
 
     /*
      * Size of the uncompressed data. This is
      * only updated when it becomes known.
      */
-    size_t        uncompressed_size;
+    uint64_t      uncompressed_size;
 
     /*
      * Spacing size in bytes, relative to the
@@ -367,10 +367,9 @@ enum {
     ZRAN_IMPORT_FAIL           = -1,
     ZRAN_IMPORT_EOF            = -2,
     ZRAN_IMPORT_READ_ERROR     = -3,
-    ZRAN_IMPORT_OVERFLOW       = -4,
-    ZRAN_IMPORT_INCONSISTENT   = -5,
-    ZRAN_IMPORT_MEMORY_ERROR   = -6,
-    ZRAN_IMPORT_UNKNOWN_FORMAT = -7
+    ZRAN_IMPORT_INCONSISTENT   = -4,
+    ZRAN_IMPORT_MEMORY_ERROR   = -5,
+    ZRAN_IMPORT_UNKNOWN_FORMAT = -6
 };
 
 /*

--- a/indexed_gzip/zran.pxd
+++ b/indexed_gzip/zran.pxd
@@ -17,6 +17,7 @@ cdef extern from "zran.h":
         size_t        uncompressed_size;
         uint32_t      spacing;
         uint32_t      window_size;
+        uint32_t      readbuf_size;
         uint32_t      npoints;
         zran_point_t *list;
 


### PR DESCRIPTION
Make `IndexedGzipFile` instances picklable, with the constraint that they must have been created with `drop_handles=True` (which is the default behaviour).

Addresses #28 