### PR TITLE
Mention requirement to pytest-cov in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ python setup.py develop
 ```
 
 
-To run the tests, type the following; you will need `numpy` and `pytest`
-installed:
+To run the tests, type the following; you will need `numpy`, `pytest`
+and `pytest-cov` installed:
 ```sh
 pytest
 ```


### PR DESCRIPTION
Running pytest, as suggested by README fails with following message:

```
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --cov=indexed_gzip
  inifile: /repo/indexed_gzip/setup.cfg
  rootdir: /repo/indexed_gzip
```

Installing `pytest-cov` plugin solves the problem.