### PR TITLE
Expose index points in IndexedGzipFile via points method

### DIFF
--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -14,4 +14,4 @@ from .indexed_gzip import (_IndexedGzipFile,     # noqa
                            ZranError)
 
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -289,6 +289,10 @@ cdef class _IndexedGzipFile:
 
         return proxy()
 
+    def seek_points(self):
+        for i in range(self.index.npoints):
+            point = self.index.list[i]
+            yield (point.uncmp_offset, point.cmp_offset)
 
     def fileno(self):
         """Calls ``fileno`` on the underlying file object. Raises a
@@ -900,6 +904,7 @@ class IndexedGzipFile(io.BufferedReader):
         self.export_index     = fobj.export_index
         self.fileobj          = fobj.fileobj
         self.drop_handles     = fobj.drop_handles
+        self.seek_points      = fobj.seek_points
 
         super(IndexedGzipFile, self).__init__(fobj, buffer_size)
 

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -609,6 +609,32 @@ def test_iter(drop):
                  next(f)
 
 
+def test_get_index_seek_points():
+
+    with testdir() as td:
+        fname   = op.join(td, 'test.gz')
+        spacing = 1048576
+
+        # make a test file
+        data = np.arange(spacing, dtype=np.uint64)
+        with gzip.open(fname, 'wb') as f:
+            f.write(data.tostring())
+
+        # check points before and after index creation
+        with igzip._IndexedGzipFile(fname, spacing=spacing) as f:
+            assert not list(f.seek_points())
+            f.build_full_index()
+
+            expected_number_of_seek_points = 1 + int(data.nbytes / spacing)
+            seek_points = list(f.seek_points())
+
+            assert len(seek_points) == expected_number_of_seek_points
+
+            # check monotonic growth
+            uncmp_offsets = [point[0] for point in seek_points]
+            assert sorted(uncmp_offsets) == uncmp_offsets
+
+
 def test_import_export_index():
 
     with testdir() as td:

--- a/indexed_gzip/tests/test_indexed_gzip.py
+++ b/indexed_gzip/tests/test_indexed_gzip.py
@@ -127,6 +127,9 @@ def test_iter():
 def test_iter_drop_handles():
     ctest_indexed_gzip.test_iter(True)
 
+def test_get_index_seek_points():
+    ctest_indexed_gzip.test_get_index_seek_points()
+
 def test_import_export_index():
     ctest_indexed_gzip.test_import_export_index()
 


### PR DESCRIPTION
Hi,
thanks for the library - it's brilliant!

My use case involves retrieving part of a gzip file from the server and reconstructing it locally with sparse files. In order to know which region of the archive has to be downloaded I need to store entry points in a database. Then I can do HTTP with Range header.

This is minimal change that does what I want (that I could come up with :smile: ). Feel free to challenge it- I know you might have different opinion on this.
If you think this change is not justified I can stick to my fork in the dependencies.