### PR TITLE
Rf/use valueerror

### DIFF
--- a/.ci/run_32bit_test.sh
+++ b/.ci/run_32bit_test.sh
@@ -31,7 +31,7 @@ fi
 
 export PATH=/mypython/bin:$PATH
 
-pip install --upgrade cython numpy pytest coverage pytest-cov
+pip install --upgrade cython numpy nibabel pytest coverage pytest-cov
 
 cd /indexed_gzip
 python setup.py develop

--- a/.ci/run_32bit_test.sh
+++ b/.ci/run_32bit_test.sh
@@ -7,7 +7,7 @@
 PYV=$PYTHON_VERSION
 
 apt-get update
-apt-get install -y libssl-dev openssl wget build-essential libffi-dev libsqlite3-dev
+apt-get install -y libssl-dev openssl wget build-essential libffi-dev libsqlite3-dev libbz2-dev
 cd /
 wget https://www.python.org/ftp/python/$PYV/Python-$PYV.tar.xz
 tar xf Python-$PYV.tar.xz

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,14 +84,14 @@ env:
   - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=rnd_131072
   - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=rnd_2000000
   - TEST_SUITE=indexed_gzip_test EXTRA_ARGS="--use_mmap" NITERS=1000 NELEMS=805306368
-  - TEST_SUITE=nibabel_test NIBABEL=2.0.* NUMPY=1.17.*
-  - TEST_SUITE=nibabel_test NIBABEL=2.1.* NUMPY=1.17.*
-  - TEST_SUITE=nibabel_test NIBABEL=2.2.* NUMPY=1.17.*
-  - TEST_SUITE=nibabel_test NIBABEL=2.3.*
-  - TEST_SUITE=nibabel_test NIBABEL=2.4.*
-  - TEST_SUITE=nibabel_test NIBABEL=2.5.*
-  - TEST_SUITE=nibabel_test NIBABEL=3.0.*
-  - TEST_SUITE=nibabel_test NIBABEL=3.1.*
+  - TEST_SUITE=nibabel_test NIBABEL="=2.0.*" NUMPY="=1.17.*"
+  - TEST_SUITE=nibabel_test NIBABEL="=2.1.*" NUMPY="=1.17.*"
+  - TEST_SUITE=nibabel_test NIBABEL="=2.2.*" NUMPY="=1.17.*"
+  - TEST_SUITE=nibabel_test NIBABEL="=2.3.*"
+  - TEST_SUITE=nibabel_test NIBABEL="=2.4.*"
+  - TEST_SUITE=nibabel_test NIBABEL="=2.5.*"
+  - TEST_SUITE=nibabel_test NIBABEL="=3.0.*"
+  - TEST_SUITE=nibabel_test NIBABEL="=3.1.*"
   - TEST_SUITE=32bittest
 
 install: "pip install --upgrade cython numpy$NUMPY nibabel$NIBABEL pytest coverage pytest-cov"

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
     - python: 3.7
       env:    TEST_SUITE=nibabel_test NIBABEL="==2.2.*" NUMPY="==1.17.*" NITERS=1 NELEMS=1
     - python: 3.7
-      env:    TEST_SUITE=nibabel_test NIBABEL="==2.3.*"                  NITERS=1 NELEMS=1
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.3.*" NUMPY="==1.17.*" NITERS=1 NELEMS=1
     - python: 3.7
       env:    TEST_SUITE=nibabel_test NIBABEL="==2.4.*"                  NITERS=1 NELEMS=1
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,43 +17,30 @@ matrix:
   # Tests covering the zran.c library.
   include:
     - python: 3.6
-      env:    TEST_SUITE=zran_test                       NITERS=5000 NELEMS=50000  TEST_PATTERN="not test_readbuf_spacing_sizes and not test_seek_then_read_block"
+      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=rnd_50000 TEST_PATTERN="not test_readbuf_spacing_sizes and not test_seek_then_read_block"
     - python: 3.6
-      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=5000 NELEMS=50000  TEST_PATTERN="not test_readbuf_spacing_sizes and not test_seek_then_read_block"
+      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=rnd_50000 TEST_PATTERN="not test_readbuf_spacing_sizes and not test_seek_then_read_block"
     - python: 3.6
-      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=50000  TEST_PATTERN="test_readbuf_spacing_sizes"
+      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=rnd_50000 TEST_PATTERN="test_readbuf_spacing_sizes"
     - python: 3.6
-      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=50000  TEST_PATTERN="test_readbuf_spacing_sizes"
+      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=rnd_50000 TEST_PATTERN="test_readbuf_spacing_sizes"
     - python: 3.6
-      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=50000  TEST_PATTERN="test_seek_then_read_block"
+      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=rnd_50000 TEST_PATTERN="test_seek_then_read_block"
     - python: 3.6
-      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=50000  TEST_PATTERN="test_seek_then_read_block"
-    - python: 3.6
-
-      env:    TEST_SUITE=zran_test                       NITERS=5000 NELEMS=131072  TEST_PATTERN="not test_readbuf_spacing_sizes and not test_seek_then_read_block"
-    - python: 3.6
-      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=5000 NELEMS=131072  TEST_PATTERN="not test_readbuf_spacing_sizes and not test_seek_then_read_block"
-    - python: 3.6
-      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=131072  TEST_PATTERN="test_readbuf_spacing_sizes"
-    - python: 3.6
-      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=131072  TEST_PATTERN="test_readbuf_spacing_sizes"
-    - python: 3.6
-      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=131072  TEST_PATTERN="test_seek_then_read_block"
-    - python: 3.6
-      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=131072  TEST_PATTERN="test_seek_then_read_block"
+      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=rnd_50000 TEST_PATTERN="test_seek_then_read_block"
 
     - python: 3.6
-      env:    TEST_SUITE=zran_test                       NITERS=5000 NELEMS=1000000  TEST_PATTERN="not test_readbuf_spacing_sizes and not test_seek_then_read_block"
+      env:    TEST_SUITE=zran_test                       NITERS=5000 NELEMS=rnd_1000000  TEST_PATTERN="not test_readbuf_spacing_sizes and not test_seek_then_read_block"
     - python: 3.6
-      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=5000 NELEMS=1000000  TEST_PATTERN="not test_readbuf_spacing_sizes and not test_seek_then_read_block"
+      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=5000 NELEMS=rnd_1000000  TEST_PATTERN="not test_readbuf_spacing_sizes and not test_seek_then_read_block"
     - python: 3.6
-      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=1000000  TEST_PATTERN="test_readbuf_spacing_sizes"
+      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=rnd_1000000  TEST_PATTERN="test_readbuf_spacing_sizes"
     - python: 3.6
-      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=1000000  TEST_PATTERN="test_readbuf_spacing_sizes"
+      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=rnd_1000000  TEST_PATTERN="test_readbuf_spacing_sizes"
     - python: 3.6
-      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=1000000  TEST_PATTERN="test_seek_then_read_block"
+      env:    TEST_SUITE=zran_test                       NITERS=1000 NELEMS=rnd_1000000  TEST_PATTERN="test_seek_then_read_block"
     - python: 3.6
-      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=1000000  TEST_PATTERN="test_seek_then_read_block"
+      env:    TEST_SUITE=zran_test EXTRA_ARGS="--concat" NITERS=1000 NELEMS=rnd_1000000  TEST_PATTERN="test_seek_then_read_block"
 
     # NELEMS=something arbitrary that is not divisible
     # by any of the default buffer/spacing sizes
@@ -94,8 +81,8 @@ python:
   - 3.8
 
 env:
-  - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=131072
-  - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=2000000
+  - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=rnd_131072
+  - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=rnd_2000000
   - TEST_SUITE=indexed_gzip_test EXTRA_ARGS="--use_mmap" NITERS=1000 NELEMS=805306368
   - TEST_SUITE=nibabel_test NIBABEL=2.0.* NUMPY=1.17.*
   - TEST_SUITE=nibabel_test NIBABEL=2.1.* NUMPY=1.17.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,14 +84,14 @@ env:
   - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=rnd_131072
   - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=rnd_2000000
   - TEST_SUITE=indexed_gzip_test EXTRA_ARGS="--use_mmap" NITERS=1000 NELEMS=805306368
-  - TEST_SUITE=nibabel_test NIBABEL="=2.0.*" NUMPY="=1.17.*"
-  - TEST_SUITE=nibabel_test NIBABEL="=2.1.*" NUMPY="=1.17.*"
-  - TEST_SUITE=nibabel_test NIBABEL="=2.2.*" NUMPY="=1.17.*"
-  - TEST_SUITE=nibabel_test NIBABEL="=2.3.*"
-  - TEST_SUITE=nibabel_test NIBABEL="=2.4.*"
-  - TEST_SUITE=nibabel_test NIBABEL="=2.5.*"
-  - TEST_SUITE=nibabel_test NIBABEL="=3.0.*"
-  - TEST_SUITE=nibabel_test NIBABEL="=3.1.*"
+  - TEST_SUITE=nibabel_test NIBABEL="==2.0.*" NUMPY="==1.17.*"
+  - TEST_SUITE=nibabel_test NIBABEL="==2.1.*" NUMPY="==1.17.*"
+  - TEST_SUITE=nibabel_test NIBABEL="==2.2.*" NUMPY="==1.17.*"
+  - TEST_SUITE=nibabel_test NIBABEL="==2.3.*"
+  - TEST_SUITE=nibabel_test NIBABEL="==2.4.*"
+  - TEST_SUITE=nibabel_test NIBABEL="==2.5.*"
+  - TEST_SUITE=nibabel_test NIBABEL="==3.0.*"
+  - TEST_SUITE=nibabel_test NIBABEL="==3.1.*"
   - TEST_SUITE=32bittest
 
 install: "pip install --upgrade cython numpy$NUMPY nibabel$NIBABEL pytest coverage pytest-cov"

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,21 +73,21 @@ matrix:
 
     # test different versions of nibabel
     - python: 3.7
-      env:    TEST_SUITE=nibabel_test NIBABEL="==2.0.*" NUMPY="==1.17.*"
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.0.*" NUMPY="==1.17.*" NITERS=1 NELEMS=1
     - python: 3.7
-      env:    TEST_SUITE=nibabel_test NIBABEL="==2.1.*" NUMPY="==1.17.*"
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.1.*" NUMPY="==1.17.*" NITERS=1 NELEMS=1
     - python: 3.7
-      env:    TEST_SUITE=nibabel_test NIBABEL="==2.2.*" NUMPY="==1.17.*"
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.2.*" NUMPY="==1.17.*" NITERS=1 NELEMS=1
     - python: 3.7
-      env:    TEST_SUITE=nibabel_test NIBABEL="==2.3.*"
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.3.*"                  NITERS=1 NELEMS=1
     - python: 3.7
-      env:    TEST_SUITE=nibabel_test NIBABEL="==2.4.*"
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.4.*"                  NITERS=1 NELEMS=1
     - python: 3.7
-      env:    TEST_SUITE=nibabel_test NIBABEL="==2.5.*"
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.5.*"                  NITERS=1 NELEMS=1
     - python: 3.7
-      env:    TEST_SUITE=nibabel_test NIBABEL="==3.0.*"
+      env:    TEST_SUITE=nibabel_test NIBABEL="==3.0.*"                  NITERS=1 NELEMS=1
     - python: 3.7
-      env:    TEST_SUITE=nibabel_test NIBABEL="==3.1.*"
+      env:    TEST_SUITE=nibabel_test NIBABEL="==3.1.*"                  NITERS=1 NELEMS=1
 
 
 # Tests covering the indexed_gzip module

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,15 +94,20 @@ python:
   - 3.8
 
 env:
-  - TEST_SUITE=indexed_gzip_test                                   NITERS=5000 NELEMS=131072
-  - TEST_SUITE=indexed_gzip_test EXTRA_ARGS="--concat"             NITERS=5000 NELEMS=131072
-  - TEST_SUITE=indexed_gzip_test                                   NITERS=5000 NELEMS=2000000
-  - TEST_SUITE=indexed_gzip_test EXTRA_ARGS="--concat"             NITERS=5000 NELEMS=2000000
-  - TEST_SUITE=indexed_gzip_test EXTRA_ARGS="--use_mmap"           NITERS=1000 NELEMS=805306368
-  - TEST_SUITE=indexed_gzip_test EXTRA_ARGS="--use_mmap --concat"  NITERS=1000 NELEMS=805306368
+  - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=131072
+  - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=2000000
+  - TEST_SUITE=indexed_gzip_test EXTRA_ARGS="--use_mmap" NITERS=1000 NELEMS=805306368
+  - TEST_SUITE=nibabel_test NIBABEL=2.0.* NUMPY=1.17.*
+  - TEST_SUITE=nibabel_test NIBABEL=2.1.* NUMPY=1.17.*
+  - TEST_SUITE=nibabel_test NIBABEL=2.2.* NUMPY=1.17.*
+  - TEST_SUITE=nibabel_test NIBABEL=2.3.*
+  - TEST_SUITE=nibabel_test NIBABEL=2.4.*
+  - TEST_SUITE=nibabel_test NIBABEL=2.5.*
+  - TEST_SUITE=nibabel_test NIBABEL=3.0.*
+  - TEST_SUITE=nibabel_test NIBABEL=3.1.*
   - TEST_SUITE=32bittest
 
-install: "pip install --upgrade cython numpy pytest coverage pytest-cov"
+install: "pip install --upgrade cython numpy$NUMPY nibabel$NIBABEL pytest coverage pytest-cov"
 
 script:
   - .ci/run_tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,24 @@ matrix:
     - python: 3.6
       env:    TEST_SUITE=zran_test EXTRA_ARGS="--use_mmap --concat"  NITERS=25   NELEMS=805306368 TEST_PATTERN="test_seek_then_read_block"
 
+    # test different versions of nibabel
+    - python: 3.7
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.0.*" NUMPY="==1.17.*"
+    - python: 3.7
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.1.*" NUMPY="==1.17.*"
+    - python: 3.7
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.2.*" NUMPY="==1.17.*"
+    - python: 3.7
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.3.*"
+    - python: 3.7
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.4.*"
+    - python: 3.7
+      env:    TEST_SUITE=nibabel_test NIBABEL="==2.5.*"
+    - python: 3.7
+      env:    TEST_SUITE=nibabel_test NIBABEL="==3.0.*"
+    - python: 3.7
+      env:    TEST_SUITE=nibabel_test NIBABEL="==3.1.*"
+
 
 # Tests covering the indexed_gzip module
 python:
@@ -84,14 +102,6 @@ env:
   - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=rnd_131072
   - TEST_SUITE=indexed_gzip_test                         NITERS=5000 NELEMS=rnd_2000000
   - TEST_SUITE=indexed_gzip_test EXTRA_ARGS="--use_mmap" NITERS=1000 NELEMS=805306368
-  - TEST_SUITE=nibabel_test NIBABEL="==2.0.*" NUMPY="==1.17.*"
-  - TEST_SUITE=nibabel_test NIBABEL="==2.1.*" NUMPY="==1.17.*"
-  - TEST_SUITE=nibabel_test NIBABEL="==2.2.*" NUMPY="==1.17.*"
-  - TEST_SUITE=nibabel_test NIBABEL="==2.3.*"
-  - TEST_SUITE=nibabel_test NIBABEL="==2.4.*"
-  - TEST_SUITE=nibabel_test NIBABEL="==2.5.*"
-  - TEST_SUITE=nibabel_test NIBABEL="==3.0.*"
-  - TEST_SUITE=nibabel_test NIBABEL="==3.1.*"
   - TEST_SUITE=32bittest
 
 install: "pip install --upgrade cython numpy$NUMPY nibabel$NIBABEL pytest coverage pytest-cov"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # `indexed_gzip` changelog
 
 
+## 1.3.2 (June 30th 2020)
+
+
+* Adjusted the `NoHandleError` and `NotCoveredError` types to sub-class from
+  `ValueError`, to preserve backwards compatibility with older versions of
+  `nibabel`.
+
+
 ## 1.3.1 (June 25th 2020)
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ install:
   - conda update  --yes -q conda
   - conda create  --yes -n test_env python=%PYTHON_VERSION%
   - activate test_env
-  - conda install --yes cython numpy nibabel zlib six pytest coverage pytest-cov
+  - conda install --yes -c conda-forge cython numpy nibabel zlib six pytest coverage pytest-cov
   - conda update --yes pytest
   - set ZLIB_HOME=%CONDA_PREFIX%\\Library
   - python setup.py develop

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,12 +61,12 @@ install:
   - conda update  --yes -q conda
   - conda create  --yes -n test_env python=%PYTHON_VERSION%
   - activate test_env
-  - conda install --yes cython numpy zlib six pytest coverage pytest-cov
+  - conda install --yes cython numpy nibabel zlib six pytest coverage pytest-cov
   - conda update --yes pytest
   - set ZLIB_HOME=%CONDA_PREFIX%\\Library
   - python setup.py develop
 
 
 test_script:
-  - pytest -v -s -m indexed_gzip_test          --niters 250
-  - pytest -v -s -m indexed_gzip_test --concat --niters 250
+  - pytest -v -s -m indexed_gzip_test          --niters 250 --nelems=rnd_16777217
+  - pytest -v -s -m indexed_gzip_test --concat --niters 250 --nelems=rnd_16777217

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,6 +62,7 @@ install:
   - conda create  --yes -n test_env --strict-channel-priority -c conda-forge python=%PYTHON_VERSION%
   - activate test_env
   - conda install --yes --strict-channel-priority -c conda-forge cython numpy nibabel zlib six pytest coverage pytest-cov
+  - conda update  --yes --strict-channel-priority -c conda-forge pytest
   - set ZLIB_HOME=%CONDA_PREFIX%\\Library
   - python setup.py develop
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,8 +61,7 @@ install:
   - conda update  --yes -q conda
   - conda create  --yes -n test_env python=%PYTHON_VERSION%
   - activate test_env
-  - conda install --yes -c conda-forge cython numpy nibabel zlib six pytest coverage pytest-cov
-  - conda update --yes pytest
+  - conda install --yes --strict-channel-priority -c conda-forge cython numpy nibabel zlib six pytest coverage pytest-cov
   - set ZLIB_HOME=%CONDA_PREFIX%\\Library
   - python setup.py develop
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,13 @@ environment:
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda update  --yes -q conda
-  - conda create  --yes -n test_env -c conda-forge python=%PYTHON_VERSION%
+  - conda create  --yes -n test_env python=%PYTHON_VERSION%
   - activate test_env
-  - conda install --yes -c conda-forge pytest==3.5
-  - conda install --yes -c conda-forge cython numpy nibabel zlib six coverage pytest-cov
+  # win32 conda-forge/pytest is old, so install
+  # as much as we can from anaconda
+  - conda install --yes pytest pytest-cov coverage cython numpy zlib six
+  # nibabel not available on anaconda channel
+  - conda install --yes -c conda-forge nibabel
   - set ZLIB_HOME=%CONDA_PREFIX%\\Library
   - python setup.py develop
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,8 +61,7 @@ install:
   - conda update  --yes -q conda
   - conda create  --yes -n test_env --strict-channel-priority -c conda-forge python=%PYTHON_VERSION%
   - activate test_env
-  - conda install --yes --strict-channel-priority -c conda-forge cython numpy nibabel zlib six pytest coverage pytest-cov
-  - conda update  --yes --strict-channel-priority -c conda-forge pytest
+  - conda install --yes --strict-channel-priority -c conda-forge cython numpy nibabel zlib six pytest==3.5 coverage pytest-cov==2.4
   - set ZLIB_HOME=%CONDA_PREFIX%\\Library
   - python setup.py develop
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,13 +59,14 @@ environment:
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda update  --yes -q conda
-  - conda create  --yes -n test_env --strict-channel-priority -c conda-forge python=%PYTHON_VERSION%
+  - conda create  --yes -n test_env -c conda-forge python=%PYTHON_VERSION%
   - activate test_env
-  - conda install --yes --strict-channel-priority -c conda-forge cython numpy nibabel zlib six pytest==3.5 coverage pytest-cov==2.4
+  - conda install --yes -c conda-forge pytest==3.5
+  - conda install --yes -c conda-forge cython numpy nibabel zlib six coverage pytest-cov
   - set ZLIB_HOME=%CONDA_PREFIX%\\Library
   - python setup.py develop
 
 
 test_script:
-  - pytest -v -s -m indexed_gzip_test          --niters 250 --nelems=rnd_16777217
-  - pytest -v -s -m indexed_gzip_test --concat --niters 250 --nelems=rnd_16777217
+  - pytest -v -s -m indexed_gzip_test          --niters 250 --nelems=rnd_1048576
+  - pytest -v -s -m indexed_gzip_test --concat --niters 250 --nelems=rnd_1048576

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ environment:
 install:
   - "set PATH=%MINICONDA%;%MINICONDA%\\Scripts;%PATH%"
   - conda update  --yes -q conda
-  - conda create  --yes -n test_env python=%PYTHON_VERSION%
+  - conda create  --yes -n test_env --strict-channel-priority -c conda-forge python=%PYTHON_VERSION%
   - activate test_env
   - conda install --yes --strict-channel-priority -c conda-forge cython numpy nibabel zlib six pytest coverage pytest-cov
   - set ZLIB_HOME=%CONDA_PREFIX%\\Library

--- a/conftest.py
+++ b/conftest.py
@@ -17,9 +17,9 @@ from indexed_gzip.tests import gen_test_data
 def pytest_addoption(parser):
 
     parser.addoption('--nelems',
-                     type=int,
+                     type=str,
                      action='store',
-                     default=2**24 + 1,
+                     default='16777217',
                      help='Number of uint64 elements for test data')
 
     parser.addoption('--concat',
@@ -48,7 +48,16 @@ def pytest_addoption(parser):
 
 @pytest.fixture
 def nelems(request):
-    return request.config.getoption('--nelems')
+    val = request.config.getoption('--nelems')
+    if val.startswith('rnd_'):
+
+        # val +/- 20%
+        val = int(val.split('_')[1])
+        var = (np.random.random() - 0.5) * val * 0.4
+        val = round(val + var)
+
+    return int(val)
+
 
 
 @pytest.fixture

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -20,4 +20,4 @@ versions of ``nibabel``.
 """
 
 
-__version__ = '1.3.1'
+__version__ = '1.3.2'

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -14,4 +14,10 @@ from .indexed_gzip import (_IndexedGzipFile,     # noqa
                            ZranError)
 
 
+SafeIndexedGzipFile = IndexedGzipFile
+"""Alias for ``IndexedGzipFile``, to preserve compatibility with older
+versions of ``nibabel``.
+"""
+
+
 __version__ = '1.3.1'

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -46,7 +46,7 @@ import logging
 log = logging.getLogger(__name__)
 
 
-class NotCoveredError(Exception):
+class NotCoveredError(ValueError):
     """Exception raised by the :class:`_IndexedGzipFile` when an attempt is
     made to seek to/read from a location that is not covered by the
     index. If the ``_IndexedGzipFile`` was created with ``auto_build=True``,
@@ -63,7 +63,7 @@ class ZranError(Exception):
     pass
 
 
-class NoHandleError(Exception):
+class NoHandleError(ValueError):
     """Exception raised by the :class:`_IndexedGzipFile` when
     ``drop_handles is True`` and an attempt is made to access the underlying
     file object.
@@ -457,8 +457,8 @@ cdef class _IndexedGzipFile:
                                   'offset {}'.format(offset))
 
         elif ret == zran.ZRAN_SEEK_INDEX_NOT_BUILT:
-            raise ValueError('Index must be completely built '
-                             'in order to seek from SEEK_END')
+            raise NotCoveredError('Index must be completely built '
+                                  'in order to seek from SEEK_END')
 
         elif ret not in (zran.ZRAN_SEEK_OK, zran.ZRAN_SEEK_EOF):
             raise ZranError('zran_seek returned unknown code: {}'.format(ret))

--- a/indexed_gzip/tests/__init__.py
+++ b/indexed_gzip/tests/__init__.py
@@ -18,7 +18,7 @@ import multiprocessing as mp
 import numpy as np
 
 
-def testdir():
+def tempdir():
     """Returnsa context manager which creates and returns a temporary
     directory, and then deletes it on exit.
     """
@@ -27,11 +27,11 @@ def testdir():
 
         def __enter__(self):
 
-            self.testdir = tempfile.mkdtemp()
-            return self.testdir
+            self.tempdir = tempfile.mkdtemp()
+            return self.tempdir
 
         def __exit__(self, *a, **kwa):
-            shutil.rmtree(self.testdir)
+            shutil.rmtree(self.tempdir)
 
     return ctx()
 

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -31,24 +31,11 @@ import indexed_gzip as igzip
 
 from . import gen_test_data
 from . import check_data_valid
-from . import testdir
+from . import tempdir
 
 from libc.stdio cimport (SEEK_SET,
                          SEEK_CUR,
                          SEEK_END)
-
-
-@contextlib.contextmanager
-def tempdir():
-    tmpdir  = tempfile.mkdtemp()
-    prevdir = os.getcwd()
-    os.chdir(tmpdir)
-
-    try:
-        yield
-    finally:
-        os.chdir(prevdir)
-        shutil.rmtree(tmpdir)
 
 
 def read_element(gzf, element, seek=True):
@@ -125,7 +112,7 @@ def test_atts(testfile, drop):
 
 def test_init_failure_cases(concat, drop):
 
-    with testdir() as td:
+    with tempdir() as td:
         testfile = op.join(td, 'test.gz')
         gen_test_data(testfile, 65536, concat)
 
@@ -164,7 +151,7 @@ def test_init_failure_cases(concat, drop):
 
 
 def test_init_success_cases(concat, drop):
-    with testdir() as td:
+    with tempdir() as td:
         testfile = op.join(td, 'test.gz')
         gen_test_data(testfile, 65536, concat)
 
@@ -237,7 +224,7 @@ def test_handles_not_dropped(testfile, nelems, seed):
 
 
 def test_manual_build():
-    with testdir() as td:
+    with tempdir() as td:
         nelems = 65536
         fname = op.join(td, 'test.gz')
 
@@ -288,7 +275,7 @@ def test_read_all(testfile, nelems, use_mmap, drop):
 
 
 def test_read_beyond_end(concat, drop):
-    with testdir() as tdir:
+    with tempdir() as tdir:
         nelems   = 65536
         testfile = op.join(tdir, 'test.gz')
 
@@ -311,7 +298,7 @@ def test_read_beyond_end(concat, drop):
 
 
 def test_seek(concat):
-    with testdir() as tdir:
+    with tempdir() as tdir:
         nelems   = 262144 # == 2MB
         testfile = op.join(tdir, 'test.gz')
         gen_test_data(testfile, nelems, concat)
@@ -401,7 +388,7 @@ def test_seek_and_tell(testfile, nelems, niters, seed, drop):
 
 
 def test_pread():
-    with testdir() as td:
+    with tempdir() as td:
         nelems = 1024
         testfile = op.join(td, 'test.gz')
         gen_test_data(testfile, nelems, False)
@@ -428,7 +415,7 @@ def test_readinto(drop):
         return sum([len(l) for l in lines[:idx]]) + idx
 
 
-    with testdir() as td:
+    with tempdir() as td:
         testfile = op.join(td, 'test.gz')
         write_text_to_gzip_file(testfile, lines)
         with igzip._IndexedGzipFile(filename=testfile, drop_handles=drop) as f:
@@ -488,7 +475,7 @@ def test_readline(drop):
     how creative
     """).strip().split('\n')
 
-    with testdir() as td:
+    with tempdir() as td:
         fname = op.join(td, 'test.gz')
         write_text_to_gzip_file(fname, lines)
 
@@ -511,7 +498,7 @@ def test_readline_sizelimit(drop):
 
     lines = ['line one', 'line two']
 
-    with testdir() as td:
+    with tempdir() as td:
         fname = op.join(td, 'test.gz')
         write_text_to_gzip_file(fname, lines)
 
@@ -547,7 +534,7 @@ def test_readlines(drop):
     test data
     """).strip().split('\n')
 
-    with testdir() as td:
+    with tempdir() as td:
         fname = op.join(td, 'test.gz')
         write_text_to_gzip_file(fname, lines)
 
@@ -568,7 +555,7 @@ def test_readlines_sizelimit(drop):
     lines = ['line one', 'line two']
     data  = '\n'.join(lines) + '\n'
 
-    with testdir() as td:
+    with tempdir() as td:
         fname = op.join(td, 'test.gz')
         write_text_to_gzip_file(fname, lines)
 
@@ -605,7 +592,7 @@ def test_iter(drop):
     unparalleled
     """).strip().split('\n')
 
-    with testdir() as td:
+    with tempdir() as td:
         fname = op.join(td, 'test.gz')
         write_text_to_gzip_file(fname, lines)
 
@@ -619,7 +606,7 @@ def test_iter(drop):
 
 def test_get_index_seek_points():
 
-    with testdir() as td:
+    with tempdir() as td:
         fname   = op.join(td, 'test.gz')
         spacing = 1048576
 
@@ -645,7 +632,7 @@ def test_get_index_seek_points():
 
 def test_import_export_index():
 
-    with testdir() as td:
+    with tempdir() as td:
         fname    = op.join(td, 'test.gz')
         idxfname = op.join(td, 'test.gzidx')
 
@@ -703,7 +690,7 @@ def test_import_export_index():
 
 def test_wrapper_class():
 
-    with testdir() as td:
+    with tempdir() as td:
         fname    = op.join(td, 'test.gz')
         idxfname = op.join(td, 'test.gzidx')
 

--- a/indexed_gzip/tests/ctest_zran.pyx
+++ b/indexed_gzip/tests/ctest_zran.pyx
@@ -48,7 +48,7 @@ from posix.mman cimport (mmap,
                          MAP_SHARED)
 
 
-from . import poll, check_data_valid
+from . import poll, check_data_valid, tempdir
 
 
 cdef extern from "sys/mman.h":
@@ -58,21 +58,6 @@ cdef extern from "sys/mman.h":
 cimport indexed_gzip.zran as zran
 
 np.import_array()
-
-
-@contextlib.contextmanager
-def tempdir():
-    """Returns a context manager which creates and returns a temporary
-    directory, and then deletes it on exit.
-    """
-    testdir = tempfile.mkdtemp()
-    prevdir = os.getcwd()
-    try:
-        os.chdir(testdir)
-        yield testdir
-    finally:
-        os.chdir(prevdir)
-        shutil.rmtree(testdir)
 
 
 cdef read_element(zran.zran_index_t *index, element, nelems, seek=True):

--- a/indexed_gzip/tests/test_nibabel_integration.py
+++ b/indexed_gzip/tests/test_nibabel_integration.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+
+import os.path as op
+import functools as ft
+
+import pytest
+
+import nibabel      as nib
+import numpy        as np
+import indexed_gzip as igzip
+
+from indexed_gzip.tests import tempdir
+
+
+pytestmark = pytest.mark.nibabel_test
+
+
+@ft.total_ordering
+class Version(object):
+    def __init__(self, vstr):
+        self.v = [int(v) for v in vstr.split('.')]
+    def __eq__(self, other):
+        return other.v == self.v
+    def __lt__(self, other):
+        for sv, ov in zip(self.v, other.v):
+            if sv > ov: return False
+            if sv < ov: return True
+        return False
+
+
+nibver = Version(nib.__version__)
+
+
+def create_random_image(shape, fname):
+    data = np.random.random(shape).astype(np.float32)
+    aff  = np.eye(4)
+    nib.Nifti1Image(data, aff, None).to_filename(fname)
+    return data
+
+def load_image(fname):
+
+    basename = op.basename(fname)[:-7]
+
+    # nibabel pre-2.1 is not indexed_gzip-aware
+    if nibver <= Version('2.1.0'):
+        fobj = igzip.IndexedGzipFile(fname)
+        fmap = nib.Nifti1Image.make_file_map()
+        fmap[basename].fileobj = fobj
+        image = nib.Nifti1Image.from_file_map(fmap)
+
+    # nibabel 2.2.x, we have to set keep_file_open='auto'
+    # to get it to use indexed_gzip
+    elif Version('2.2.0') <= nibver < Version('2.3.0'):
+        image = nib.load(fname, keep_file_open='auto')
+
+    # nibabel >= 2.3.x uses indexed_gzip automatically
+    else:
+        image = nib.load(fname)
+
+    return image
+
+
+def test_nibabel_integration():
+    with tempdir():
+
+        data = create_random_image((50, 50, 50, 50), 'image.nii.gz')
+        image = load_image('image.nii.gz')
+
+        idata = np.asanyarray(image.dataobj)
+        assert np.all(np.isclose(data, idata))
+        assert not image.in_memory
+
+        if nibver < Version('2.2.0'):
+            assert isinstance(image.file_map['image'].fileobj,
+                              igzip.IndexedGzipFile)
+        else:
+            assert isinstance(image.dataobj._opener.fobj,
+                              igzip.IndexedGzipFile)
+
+
+# https://github.com/pauldmccarthy/indexed_gzip/issues/40
+def test_readdata_twice():
+    with tempdir():
+        # the bug only occurs on relatively small images,
+        # where the full index comprises only one or two
+        # index points
+        data = create_random_image((10, 10, 10, 10), 'image.nii.gz')
+        image = load_image('image.nii.gz')
+
+        d1 = np.asanyarray(image.dataobj)
+        d2 = np.asanyarray(image.dataobj)
+
+        assert np.all(np.isclose(data, d1))
+        assert np.all(np.isclose(data, d2))

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,7 @@ test=pytest
 [tool:pytest]
 testpaths = indexed_gzip/tests
 addopts   = -v --cov=indexed_gzip
+markers   =
+    zran_test:         Test the zran.c library
+    indexed_gzip_test: Test the indexed_gzip library
+    nibabel_test:      Test interaction between indexed_gzip and nibabel/numpy

--- a/setup.py
+++ b/setup.py
@@ -229,6 +229,6 @@ setup(
 
     ext_modules=extensions,
 
-    tests_require=['pytest', 'numpy', 'coverage', 'pytest-cov'],
+    tests_require=['pytest', 'numpy', 'nibabel', 'coverage', 'pytest-cov'],
     test_suite='tests',
 )


### PR DESCRIPTION
Fixes #40 

`indexed_gzip` error types now sub-class `ValueError`. This is to preserve compatibiltiy with older versions of `nibabel`.

Also added an alias for `IndexedGzipFile` called `SafeIndexedGzipFile`, again to preserve `nibabel` compatibity.

And re-jigged the unit tests a bit to introduce some more randomness for the aim of covering edge-cases. This might be opening a can of worms...