### PR TITLE
RF: Subclass ZranError from IOError

### DIFF
--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -56,7 +56,7 @@ class NotCoveredError(ValueError):
     pass
 
 
-class ZranError(Exception):
+class ZranError(IOError):
     """Exception raised by the :class:`_IndexedGzipFile` when the ``zran``
     library signals an error.
     """


### PR DESCRIPTION
IndexedGzipFile often returns ZranErrors where gzip.GzipFile returns IOErrors (alias for OSError in Python 3.3+).

Subclassing IOError is the simplest way to unify the APIs, although there may be ZranErrors that are not IOErrors in the usual sense.

---

For context, we get bug reports for ZranErrors in https://github.com/nipreps/fmriprep/issues/1717 and https://github.com/nipreps/fmriprep/issues/2324 when users have uncompressed files with `.gz` extensions. If indexed-gzip isn't installed, then Nibabel returns `ImageFileError: Cannot work out file type of ...` on the same file because it checks for IOErrors.

An alternative is to specifically check for ZranErrors in nibabel if indexed_gzip is detected. If this doesn't work, then I'll probably do that.

As yet another alternative if there are non-IO ZranErrors, we could use mix-in the appropriate builtin error, such as:

```Python
class ZranIOError(ZranError, IOError):
    pass
```