### PR TITLE
FIX: Allow IndexedGzipFile to be deepcopied

### DIFF
--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -734,7 +734,7 @@ cdef class _IndexedGzipFile:
 
         else:
             close_file = False
-            if fileobj.mode != 'wb':
+            if getattr(fileobj, 'mode', 'wb') != 'wb':
                 raise ValueError(
                     'File should be opened write-only binary mode.')
 

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -12,6 +12,7 @@ import itertools       as it
 import functools       as ft
 import subprocess      as sp
 import multiprocessing as mp
+import copy            as cp
 import                    sys
 import                    time
 import                    gzip
@@ -166,6 +167,7 @@ def test_init_success_cases(concat, drop):
         gf1.close()
         gf2.close()
         gf3.close()
+
 
 def test_create_from_open_handle(testfile, nelems, seed, drop):
 
@@ -797,6 +799,60 @@ def test_picklable():
             pickled = pickle.dumps(gzf)
         gzf.close()
         del gzf
+
+
+def test_copyable():
+    # IndexedGzipFile should be copyable whether it retains or drops filehandles
+    fname = 'test.gz'
+
+    with tempdir():
+        data = np.random.randint(1, 1000, (1000, 1000), dtype=np.uint32)
+        with gzip.open(fname, 'wb') as f:
+            f.write(data.tobytes())
+        del f
+
+        gzf       = igzip.IndexedGzipFile(fname)
+        gzf_copy  = cp.deepcopy(gzf)
+        first2MB  = gzf.read(1048576 * 2)
+        gzf_copy2 = cp.deepcopy(gzf)
+        second2MB = gzf.read(1048576 * 2)
+
+        gzf.close()
+        del gzf
+
+        assert gzf_copy.tell() == 0
+        assert gzf_copy2.tell() == 1048576 * 2
+        assert gzf_copy.read(1048576 * 2) == first2MB
+        assert gzf_copy2.read(1048576 * 2) == second2MB
+        gzf_copy2.seek(0)
+        assert gzf_copy2.read(1048576 * 2) == first2MB
+        gzf_copy.close()
+        gzf_copy2.close()
+        del gzf_copy
+        del gzf_copy2
+
+    with tempdir():
+        data = np.random.randint(1, 1000, 50000, dtype=np.uint32)
+        with gzip.open(fname, 'wb') as f:
+            f.write(data.tobytes())
+        del f
+
+        # if drop_handles=False, no copy
+        gzf = igzip.IndexedGzipFile(fname, drop_handles=False)
+
+        with pytest.raises(pickle.PicklingError):
+            gzf_copy = cp.deepcopy(gzf)
+        gzf.close()
+        del gzf
+
+        # If passed an open filehandle, no copy
+        with open(fname, 'rb') as fobj:
+            gzf = igzip.IndexedGzipFile(fileobj=fobj)
+            with pytest.raises(pickle.PicklingError):
+                gzf_copy = cp.deepcopy(gzf)
+            gzf.close()
+            del gzf
+        del fobj
 
 
 def _mpfunc(gzf, size, offset):

--- a/indexed_gzip/tests/test_indexed_gzip.py
+++ b/indexed_gzip/tests/test_indexed_gzip.py
@@ -144,6 +144,9 @@ def test_size_multiple_of_readbuf():
 def test_picklable():
     ctest_indexed_gzip.test_picklable()
 
+def test_copyable():
+    ctest_indexed_gzip.test_copyable()
+
 @pytest.mark.slow_test
 def test_multiproc_serialise():
     ctest_indexed_gzip.test_multiproc_serialise()


### PR DESCRIPTION
Starting with a test to trigger your CI, since I'm not set up to build and test locally.

Inspired by https://github.com/nipy/nibabel/issues/969