### PR TITLE
WIP: BF, CI: Fix serialise bug

### DIFF
--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -36,8 +36,10 @@ from cpython.buffer cimport (PyObject_GetBuffer,
 cimport indexed_gzip.zran as zran
 
 import io
+import os
 import pickle
 import warnings
+import tempfile
 import contextlib
 import threading
 import logging
@@ -734,12 +736,13 @@ cdef class _IndexedGzipFile:
 
         else:
             close_file = False
-            if getattr(fileobj, 'mode', 'wb') != 'wb':
+            if (not fileobj.writable()) or \
+               ('b' not in getattr(fileobj, 'mode', 'wb')):
                 raise ValueError(
-                    'File should be opened write-only binary mode.')
+                    'File should be opened in writeable binary mode.')
 
         try:
-            fd  = fdopen(fileobj.fileno(), 'ab')
+            fd  = fdopen(fileobj.fileno(), 'wb')
             ret = zran.zran_export_index(&self.index, fd)
             if ret != zran.ZRAN_EXPORT_OK:
                 raise ZranError('export_index returned error: {}'.format(ret))
@@ -776,7 +779,8 @@ cdef class _IndexedGzipFile:
 
         else:
             close_file = False
-            if fileobj.mode != 'rb':
+            if (not fileobj.readable()) or \
+               ('b' not in getattr(fileobj, 'mode', 'rb')):
                 raise ValueError(
                     'File should be opened read-only binary mode.')
 
@@ -948,14 +952,27 @@ class IndexedGzipFile(io.BufferedReader):
                 'with an open file object, or that has been created '
                 'with drop_handles=False')
 
-        # export and serialise the
-        # index if any index points
-        # have been created
-        if fobj.npoints > 0:
-            index = io.BytesIO()
-            self.export_index(fileobj=index)
-        else:
+        # export and serialise the index if
+        # any index points have been created.
+        # The index data is serialised as a
+        # bytes object.
+        if fobj.npoints == 0:
             index = None
+
+        else:
+            # zran.c:zran_export_index requires a file
+            # descriptor, so we give it a tempoorary
+            # file, and then read the bytes into memory.
+            tmpfile = None
+            try:
+                tmpfile = tempfile.NamedTemporaryFile(delete=False)
+                tmpfile.close()
+                self.export_index(tmpfile.name)
+                with open(tmpfile.name, 'rb') as f:
+                    index = f.read()
+            finally:
+                if tmpfile is not None:
+                    os.remove(tmpfile.name)
 
         state = {
             'filename'         : fobj.filename,
@@ -985,9 +1002,20 @@ def unpickle(state):
     gzobj = IndexedGzipFile(**state)
 
     if index is not None:
-        index.seek(0)
-        gzobj.import_index(fileobj=index)
-        index.close()
+        tmpfile = None
+        try:
+            # zran.c:zran_import_index requires an
+            # actual file with a file descriptor,
+            # so we write the index data out to a
+            # temp file, and then pass the file in.
+            tmpfile = tempfile.NamedTemporaryFile(delete=False)
+            tmpfile.write(index)
+            tmpfile.close()
+            gzobj.import_index(tmpfile.name)
+
+        finally:
+            if tmpfile is not None:
+                os.remove(tmpfile.name)
     gzobj.seek(tell)
 
     return gzobj

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -734,7 +734,7 @@ cdef class _IndexedGzipFile:
 
         else:
             close_file = False
-            if fileobj.mode != 'wb':
+            if getattr(fileobj, 'mode', 'wb') != 'wb':
                 raise ValueError(
                     'File should be opened write-only binary mode.')
 

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -736,8 +736,7 @@ cdef class _IndexedGzipFile:
 
         else:
             close_file = False
-            if (not fileobj.writable()) or \
-               ('b' not in getattr(fileobj, 'mode', 'wb')):
+            if getattr(fileobj, 'mode', 'wb') != 'wb':
                 raise ValueError(
                     'File should be opened in writeable binary mode.')
 
@@ -779,8 +778,7 @@ cdef class _IndexedGzipFile:
 
         else:
             close_file = False
-            if (not fileobj.readable()) or \
-               ('b' not in getattr(fileobj, 'mode', 'rb')):
+            if getattr(fileobj, 'mode', 'rb') != 'rb':
                 raise ValueError(
                     'File should be opened read-only binary mode.')
 

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -12,6 +12,7 @@ import itertools       as it
 import functools       as ft
 import subprocess      as sp
 import multiprocessing as mp
+import copy            as cp
 import                    sys
 import                    time
 import                    gzip
@@ -166,6 +167,7 @@ def test_init_success_cases(concat, drop):
         gf1.close()
         gf2.close()
         gf3.close()
+
 
 def test_create_from_open_handle(testfile, nelems, seed, drop):
 
@@ -797,6 +799,60 @@ def test_picklable():
             pickled = pickle.dumps(gzf)
         gzf.close()
         del gzf
+
+
+def test_copyable():
+    # IndexedGzipFile should be copyable whether it retains or drops filehandles
+    fname = 'test.gz'
+
+    with tempdir():
+        data = np.random.randint(1, 1000, (1000, 1000), dtype=np.uint32)
+        with gzip.open(fname, 'wb') as f:
+            f.write(data.tobytes())
+        del f
+
+        gzf       = igzip.IndexedGzipFile(fname)
+        gzf_copy  = cp.deepcopy(gzf)
+        first2MB  = gzf.read(1048576 * 2)
+        gzf_copy2 = cp.deepcopy(gzf)
+        second2MB = gzf.read(1048576 * 2)
+
+        gzf.close()
+        del gzf
+
+        assert gzf_copy.tell() == 0
+        assert gzf_copy2.tell() == 1048576 * 2
+        assert gzf_copy.read(1048576 * 2) == first2MB
+        assert gzf_copy2.read(1048576 * 2) == second2MB
+        gzf_copy2.seek(0)
+        assert gzf_copy2.read(1048576 * 2) == first2MB
+        gzf_copy.close()
+        gzf_copy2.close()
+        del gzf_copy
+        del gzf_copy2
+
+    with tempdir():
+        data = np.random.randint(1, 1000, 50000, dtype=np.uint32)
+        with gzip.open(fname, 'wb') as f:
+            f.write(data.tobytes())
+        del f
+
+        # if drop_handles=False, no copy
+        gzf = igzip.IndexedGzipFile(fname, drop_handles=False)
+
+        with pytest.raises(pickle.PicklingError):
+            gzf_copy = cp.deepcopy(gzf)
+        gzf.close()
+        del gzf
+
+        # If passed an open filehandle, no copy
+        with open(fname, 'rb') as fobj:
+            gzf = igzip.IndexedGzipFile(fileobj=fobj)
+            with pytest.raises(pickle.PicklingError):
+                gzf_copy = cp.deepcopy(gzf)
+            gzf.close()
+            del gzf
+        del fobj
 
 
 def _mpfunc(gzf, size, offset):

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -772,8 +772,10 @@ def test_picklable():
 
         gzf        = igzip.IndexedGzipFile(fname)
         first50MB  = gzf.read(1048576 * 50)
+        gzf.seek(gzf.tell())
         pickled    = pickle.dumps(gzf)
         second50MB = gzf.read(1048576 * 50)
+        gzf.seek(gzf.tell())
 
         gzf.close()
         del gzf
@@ -802,30 +804,31 @@ def test_picklable():
 
 
 def test_copyable():
-    # IndexedGzipFile should be copyable whether it retains or drops filehandles
     fname = 'test.gz'
 
     with tempdir():
-        data = np.random.randint(1, 1000, (1000, 1000), dtype=np.uint32)
+        data = np.random.randint(1, 1000, (10000, 10000), dtype=np.uint32)
         with gzip.open(fname, 'wb') as f:
             f.write(data.tobytes())
         del f
 
-        gzf       = igzip.IndexedGzipFile(fname)
-        gzf_copy  = cp.deepcopy(gzf)
-        first2MB  = gzf.read(1048576 * 2)
-        gzf_copy2 = cp.deepcopy(gzf)
-        second2MB = gzf.read(1048576 * 2)
+        gzf        = igzip.IndexedGzipFile(fname)
+        gzf_copy   = cp.deepcopy(gzf)
+        first50MB  = gzf.read(1048576 * 50)
+        gzf.seek(gzf.tell())
+        gzf_copy2  = cp.deepcopy(gzf)
+        second50MB = gzf.read(1048576 * 50)
+        gzf.seek(gzf.tell())
 
         gzf.close()
         del gzf
 
         assert gzf_copy.tell() == 0
-        assert gzf_copy2.tell() == 1048576 * 2
-        assert gzf_copy.read(1048576 * 2) == first2MB
-        assert gzf_copy2.read(1048576 * 2) == second2MB
+        assert gzf_copy2.tell() == 1048576 * 50
+        assert gzf_copy.read(1048576 * 50) == first50MB
+        assert gzf_copy2.read(1048576 * 50) == second50MB
         gzf_copy2.seek(0)
-        assert gzf_copy2.read(1048576 * 2) == first2MB
+        assert gzf_copy2.read(1048576 * 50) == first50MB
         gzf_copy.close()
         gzf_copy2.close()
         del gzf_copy

--- a/indexed_gzip/tests/test_indexed_gzip.py
+++ b/indexed_gzip/tests/test_indexed_gzip.py
@@ -144,6 +144,9 @@ def test_size_multiple_of_readbuf():
 def test_picklable():
     ctest_indexed_gzip.test_picklable()
 
+def test_copyable():
+    ctest_indexed_gzip.test_copyable()
+
 @pytest.mark.slow_test
 def test_multiproc_serialise():
     ctest_indexed_gzip.test_multiproc_serialise()


### PR DESCRIPTION
See #50 - This MR addresses a bug in the `IndexedGzipFile.__reduce__` method, which is used when pickling/serialising an `IndexedGzipFile` object.