### PR TITLE
Rel/1.5.0

### DIFF
--- a/AUTHOR
+++ b/AUTHOR
@@ -1,0 +1,8 @@
+Paul McCarthy (@pauldmccarthy)
+Zalan Rajna (@zrajna)
+Martin Craig (@mcraig-ibme)
+Chris Markiewicz (@effigies)
+Omer Ozarslan (@ozars)
+@DarioDaF
+Sławomir Zborowski (@szborows)
+Ashwin Ramaswami (@epicfaace)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # `indexed_gzip` changelog
 
 
-## 1.5.0 (March 18th 2021)
+## 1.5.0 (March 19th 2021)
 
 
 * Added support for in-memory file objects (#55).
+* Fixed a bug whereby a segmentation fault could occur if an `IndexedGzipFile`
+  was created with a path to a non-existent file (#56).
 
 
 ## 1.4.0 (January 2nd 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # `indexed_gzip` changelog
 
 
+## 1.5.0 (March 18th 2021)
+
+
+* Added support for in-memory file objects (#55).
+
+
 ## 1.4.0 (January 2nd 2021)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## 1.5.0 (March 19th 2021)
 
 
-* Added support for in-memory file objects (#55).
+* Added support for in-memory file-like objects (#55).
 * Fixed a bug whereby a segmentation fault could occur if an `IndexedGzipFile`
   was created with a path to a non-existent file (#56).
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-indexed_gzip: Copyright (C) 2016-2020 Paul McCarthy
+indexed_gzip: Copyright (C) 2016-2021 Paul McCarthy
 
 zlib: Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,26 @@ data = myfile.read(1048576)
 ```
 
 
+## Using with in-memory data
+
+You can use `indexed_gzip` with any Python file-like object. For example:
+
+```python
+
+import io
+import indexed_gzip as igzip
+
+# Load some gzip data from somewhere
+with open('my_file.gz') as f:
+    data = f.read()
+
+# Create an IndexedGzipFile based on the
+# in-memory data buffer
+gzf = igzip.IndexedGzipFile(fileobj=io.BytesIO(data))
+uncompressed = gzf.read(1048576)
+```
+
+
 ## Using with `nibabel`
 
 
@@ -132,8 +152,8 @@ image = nib.load('big_image.nii.gz')
 ```
 
 
-If you are using `nibabel` 2.2.x, you need to explicitly set the `keep_file_open`
-flag:
+If you are using `nibabel` 2.2.x, you need to explicitly set the
+`keep_file_open` flag:
 
 
 ```python
@@ -202,10 +222,10 @@ fobj = igzip.IndexedGzipFile('big_file.gz', index_file='big_file.gzidx')
 ## Write support
 
 
-`indexed_gzip` does not currently have any support for writing. Currently if you
-wish to write to a file, you will need to save the file by alternate means (e.g.
-via `gzip` or `nibabel`), and then re-create a new `IndexedGzipFile` instance.
-For example:
+`indexed_gzip` does not currently have any support for writing. Currently if
+you wish to write to a file, you will need to save the file by alternate means
+(e.g.  via `gzip` or `nibabel`), and then re-create a new `IndexedGzipFile`
+instance.  For example:
 
 
 ```python

--- a/README.md
+++ b/README.md
@@ -275,16 +275,16 @@ Initial work on `indexed_gzip` took place at
 [FMRIB Centre](https://www.ndcn.ox.ac.uk/divisions/fmrib/), at the
 University of Oxford, UK.
 
-
 Many thanks to the following contributors (listed chronologically):
 
- - Zalan Rajna (@zrajna): bug fixes (#2)
- - Martin Craig (@mcraig-ibme): porting `indexed_gzip` to Windows (#3)
+ - Zalan Rajna (@zrajna): Bug fixes (#2)
+ - Martin Craig (@mcraig-ibme): Porting `indexed_gzip` to Windows (#3)
  - Chris Markiewicz (@effigies): Option to drop file handles (#6)
  - Omer Ozarslan (@ozars): Index import/export (#8)
  - @DarioDaF: Windows overflow bug (#30)
  - Sławomir Zborowski (@szborows): `seek_points` method (#35), README fixes
    (#34)
+ - Ashwin Ramaswami (@epicfaace): Support for in-memory file objects (#55)
 
 
 ## License

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -19,4 +19,4 @@ versions of ``nibabel``.
 """
 
 
-__version__ = '1.4.0'
+__version__ = '1.5.0'

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -2,8 +2,6 @@
 #
 # __init__.py - The indexed_gzip namespace.
 #
-# Author: Paul McCarthy <pauldmccarthy@gmail.com>
-#
 """The indexed_gzip namespace. """
 
 

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -181,6 +181,7 @@ class IndexedGzipFile(io.BufferedReader):
         else:
             index = io.BytesIO()
             self.export_index(fileobj=index)
+            index = index.getvalue()
 
         state = {
             'filename'         : fobj.filename,
@@ -1028,7 +1029,7 @@ def unpickle(state):
     gzobj = IndexedGzipFile(**state)
 
     if index is not None:
-        gzobj.import_index(fileobj=index)
+        gzobj.import_index(fileobj=io.BytesIO(index))
 
     gzobj.seek(tell)
 

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -2,8 +2,6 @@
 #
 # The IndexedGzipFile class.
 #
-# Author: Paul McCarthy <pauldmccarthy@gmail.com>
-#
 
 """This module provides the :class:`IndexedGzipFile` class, a drop-in
 replacement for the built-in ``gzip.GzipFile`` class, for faster read-only

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -423,7 +423,7 @@ cdef class _IndexedGzipFile:
             # context manager reentrant.
             if self.index.fd is not NULL:
                 yield
-            
+
             # If a file-like object exists (without an associated
             # file descriptor, since self.index.fd is NULL),
             # also return it.
@@ -505,7 +505,8 @@ cdef class _IndexedGzipFile:
         self.pyfid     = None
         self.finalized = True
 
-        log.debug('%s.close()', type(self).__name__)
+        if log is not None:
+            log.debug('%s.close()', type(self).__name__)
 
 
     @property

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -601,12 +601,8 @@ cdef class _IndexedGzipFile:
         if whence not in (SEEK_SET, SEEK_CUR, SEEK_END):
             raise ValueError('Invalid value for whence: {}'.format(whence))
 
-        if index.fd == NULL:
-            with self.__file_handle():
-                ret = zran.zran_seek(index, off, c_whence, NULL)
-        else:
-            with self.__file_handle(), nogil:
-                ret = zran.zran_seek(index, off, c_whence, NULL)
+        with self.__file_handle(), nogil:
+            ret = zran.zran_seek(index, off, c_whence, NULL)
 
         if ret < 0:
             raise ZranError('zran_seek returned error: {}'.format(ret))
@@ -660,11 +656,8 @@ cdef class _IndexedGzipFile:
                 # buffer location
                 buffer = <char *>buf.buffer + offset
 
-                if index.fd == NULL:
+                with nogil:
                     ret = zran.zran_read(index, buffer, bufsz)
-                else:
-                    with nogil:
-                        ret = zran.zran_read(index, buffer, bufsz)
 
                 # see how the read went
                 if ret == zran.ZRAN_READ_FAIL:
@@ -729,12 +722,8 @@ cdef class _IndexedGzipFile:
         try:
 
             vbuf = <void *>pbuf.buf
-            if index.fd == NULL:
-                with self.__file_handle():
-                    ret = zran.zran_read(index, vbuf, bufsz)
-            else:
-                with self.__file_handle(), nogil:
-                    ret = zran.zran_read(index, vbuf, bufsz)
+            with self.__file_handle(), nogil:
+                ret = zran.zran_read(index, vbuf, bufsz)
 
         # release the py_buffer
         finally:

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -886,10 +886,13 @@ cdef class _IndexedGzipFile:
                     'File should be opened in writeable binary mode.')
 
         try:
+            # Pass both the Python file object and
+            # file descriptor (if this is an actual
+            # file) to the zran_export_index function
             try:
-                fd  = fdopen(fileobj.fileno(), 'wb')
+                fd = fdopen(fileobj.fileno(), 'wb')
             except io.UnsupportedOperation:
-                fd  = NULL
+                fd = NULL
             ret = zran.zran_export_index(&self.index, fd, <PyObject*>fileobj)
             if ret != zran.ZRAN_EXPORT_OK:
                 raise ZranError('export_index returned error: {}'.format(ret))
@@ -931,10 +934,13 @@ cdef class _IndexedGzipFile:
                     'File should be opened read-only binary mode.')
 
         try:
+            # Pass both the Python file object and
+            # file descriptor (if this is an actual
+            # file) to the zran_import_index function
             try:
-                fd  = fdopen(fileobj.fileno(), 'rb')
+                fd = fdopen(fileobj.fileno(), 'rb')
             except io.UnsupportedOperation:
-                fd  = NULL
+                fd = NULL
             ret = zran.zran_import_index(&self.index, fd, <PyObject*>fileobj)
             if ret != zran.ZRAN_IMPORT_OK:
                 raise ZranError('import_index returned error: {}'.format(ret))

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -40,7 +40,6 @@ import            os
 import os.path as op
 import            pickle
 import            logging
-import            tempfile
 import            warnings
 import            threading
 import            contextlib

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -35,14 +35,15 @@ from cpython.ref cimport PyObject
 
 cimport indexed_gzip.zran as zran
 
-import io
-import os
-import pickle
-import logging
-import tempfile
-import warnings
-import threading
-import contextlib
+import            io
+import            os
+import os.path as op
+import            pickle
+import            logging
+import            tempfile
+import            warnings
+import            threading
+import            contextlib
 
 
 builtin_open = open
@@ -332,6 +333,14 @@ cdef class _IndexedGzipFile:
         if  hasattr(filename, 'read'):
             fileobj  = filename
             filename = None
+
+        # If __file_handle is called on a file
+        # that doesn't exist, it passes the
+        # path directly to fopen, which causes
+        # a segmentation faullt on linux. So
+        # let's check before that happens.
+        if (filename is not None) and (not op.isfile(filename)):
+            raise ValueError('File {} does not exist'.format(filename))
 
         mode     = 'rb'
         own_file = fileobj is None

--- a/indexed_gzip/tests/__init__.py
+++ b/indexed_gzip/tests/__init__.py
@@ -49,7 +49,7 @@ def poll(until):
     while not until():
         time.sleep(0.5)
         cur = time.time()
-        elapsed = cur - start
+        elapsed = int(round(cur - start))
         if int(elapsed) % 60 == 0:
             print('Waiting ({:0.2f} minutes)'.format(elapsed / 60.0))
 

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -33,6 +33,7 @@ import indexed_gzip as igzip
 from . import gen_test_data
 from . import check_data_valid
 from . import tempdir
+from . import compress
 
 from libc.stdio cimport (SEEK_SET,
                          SEEK_CUR,
@@ -754,7 +755,7 @@ def test_import_export_index():
             with open(idxfname, 'wb') as idxf:
                 f.export_index(fileobj=idxf)
 
-        # Check that it works
+        # Check that we can read it back
         with igzip._IndexedGzipFile(fname) as f:
 
             # Should raise if wrong permissions
@@ -858,8 +859,9 @@ def test_picklable():
 
     with tempdir():
         data = np.random.randint(1, 1000, (10000, 10000), dtype=np.uint32)
-        with gzip.open(fname, 'wb') as f:
+        with open(fname+'.bin', 'wb') as f:
             f.write(data.tobytes())
+        compress(fname+'.bin', fname)
         del f
 
         gzf        = igzip.IndexedGzipFile(fname)
@@ -900,8 +902,9 @@ def test_copyable():
 
     with tempdir():
         data = np.random.randint(1, 1000, (10000, 10000), dtype=np.uint32)
-        with gzip.open(fname, 'wb') as f:
+        with open(fname+'.bin', 'wb') as f:
             f.write(data.tobytes())
+        compress(fname+'.bin', fname)
         del f
 
         gzf        = igzip.IndexedGzipFile(fname)

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -5,8 +5,6 @@
  *
  * This module was originally based on the zran example, written by Mark
  * Alder, which ships with the zlib source code.
- *
- * Author: Paul McCarthy <pauldmccarthy@gmail.com>
  */
 
 #include <math.h>

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -6,8 +6,6 @@
  * Alder, which ships with the zlib source code. It allows the creation
  * of an index into a compressed file, which is used to improve the speed
  * of random seek/read access to the uncompressed data.
- *
- * Author: Paul McCarthy <pauldmccarthy@gmail.com>
  */
 
 #include <stdlib.h>

--- a/indexed_gzip/zran.pxd
+++ b/indexed_gzip/zran.pxd
@@ -1,8 +1,6 @@
 #
 # Cython declaration for the zran library.
 #
-# Author: Paul McCarthy <pauldmccarthy@gmail.com>
-#
 
 from libc.stdio  cimport FILE
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, int64_t

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -1,9 +1,6 @@
 /*
  * zran_file_util.c - file utilities used in zran.c to manipulate either
  * Python file-like objects or file descriptors.
- *
- *
- * Author: Paul McCarthy <pauldmccarthy@gmail.com>
  */
 
 #include <math.h>

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -1,6 +1,9 @@
 /*
  * zran_file_util.c - file utilities used in zran.c to manipulate either
  * Python file-like objects or file descriptors.
+ *
+ * Functions which interact with Python file-likes will acquire and release
+ * the GIL as needeed.
  */
 
 #include <math.h>
@@ -24,122 +27,190 @@
 #define FTELL ftello
 #endif
 
+/*
+ * The zran functions are typically called with the GIL released. These
+ * macros are used to temporarily (re-)acquire and release the GIL when
+ * interacting with Python file-like objects.
+ */
+#define _ZRAN_FILE_UTIL_ACQUIRE_GIL \
+    PyGILState_STATE s;             \
+    s = PyGILState_Ensure();
+
+#define _ZRAN_FILE_UTIL_RELEASE_GIL \
+    PyGILState_Release(s);
+
 
 /*
- * Implements a method analogous to fread that is performed on Python file-like objects.
+ * Implements a method analogous to fread that is performed on Python
+ * file-like objects.
  */
 size_t _fread_python(void *ptr, size_t size, size_t nmemb, PyObject *f) {
-    PyObject *data;
-    char *buf;
+
+    PyObject  *data;
+    char      *buf;
     Py_ssize_t len;
+
+    _ZRAN_FILE_UTIL_ACQUIRE_GIL
+
     if ((data = PyObject_CallMethod(f, "read", "(n)", size * nmemb)) == NULL)
         goto fail;
     if ((buf = PyBytes_AsString(data)) == NULL)
         goto fail;
     if ((len = PyBytes_Size(data)) == -1)
         goto fail;
+
     memmove(ptr, buf, (size_t) len);
+
     Py_DECREF(data);
+    _ZRAN_FILE_UTIL_RELEASE_GIL
     return (size_t) len / size;
 
 fail:
     Py_XDECREF(data);
+    _ZRAN_FILE_UTIL_RELEASE_GIL
     return 0;
 }
 
 /*
- * Implements a method analogous to ftell that is performed on Python file-like objects.
+ * Implements a method analogous to ftell that is performed on Python
+ * file-like objects.
  */
 int64_t _ftell_python(PyObject *f) {
     PyObject *data;
-    int64_t result;
-    if ((data = PyObject_CallMethod(f, "tell", NULL)) == NULL)
+    int64_t   result;
+
+    _ZRAN_FILE_UTIL_ACQUIRE_GIL
+
+    data = PyObject_CallMethod(f, "tell", NULL);
+    if (data == NULL)
         goto fail;
-    if ((result = PyLong_AsLong(data)) == -1 && PyErr_Occurred())
+
+    result = PyLong_AsLong(data);
+    if (result == -1 && PyErr_Occurred())
         goto fail;
+
     Py_DECREF(data);
+    _ZRAN_FILE_UTIL_RELEASE_GIL
     return result;
 
 fail:
     Py_XDECREF(data);
+    _ZRAN_FILE_UTIL_RELEASE_GIL
     return -1;
 }
 
 /*
- * Implements a method analogous to fseek that is performed on Python file-like objects.
+ * Implements a method analogous to fseek that is performed on Python
+ * file-like objects.
  */
 int _fseek_python(PyObject *f, int64_t offset, int whence) {
+
     PyObject *data;
-    if ((data = PyObject_CallMethod(f, "seek", "(l,i)", offset, whence)) == NULL)
+
+    _ZRAN_FILE_UTIL_ACQUIRE_GIL
+
+    data = PyObject_CallMethod(f, "seek", "(l,i)", offset, whence);
+    if (data == NULL)
         goto fail;
+
     Py_DECREF(data);
+    _ZRAN_FILE_UTIL_RELEASE_GIL
     return 0;
 
 fail:
     Py_XDECREF(data);
+    _ZRAN_FILE_UTIL_RELEASE_GIL
     return -1;
 }
 
 /*
- * Implements a method analogous to feof that is performed on Python file-like objects.
- * If f_ret, the number of bytes returned by the last read, is zero, then we're at EOF.
+ * Implements a method analogous to feof that is performed on Python file-like
+ * objects.  If f_ret, the number of bytes returned by the last read, is zero,
+ * then we're at EOF.
  */
 int _feof_python(PyObject *f, size_t f_ret) {
     return f_ret == 0;
 }
 
 /*
- * Implements a method analogous to ferror that is performed on Python file-like objects.
+ * Implements a method analogous to ferror that is performed on Python
+ * file-like objects.
  */
 int _ferror_python(PyObject *f) {
-    return PyErr_Occurred() ? 1 : 0;
+    int result;
+
+    _ZRAN_FILE_UTIL_ACQUIRE_GIL
+    result = PyErr_Occurred();
+    _ZRAN_FILE_UTIL_RELEASE_GIL
+
+    if (result != NULL) return 1;
+    else                return 0;
 }
 
 /*
- * Implements a method analogous to fflush that is performed on Python file-like objects.
+ * Implements a method analogous to fflush that is performed on Python
+ * file-like objects.
  */
 int _fflush_python(PyObject *f) {
     PyObject *data;
+
+    _ZRAN_FILE_UTIL_ACQUIRE_GIL
     if ((data = PyObject_CallMethod(f, "flush", NULL)) == NULL) goto fail;
+
     Py_DECREF(data);
+    _ZRAN_FILE_UTIL_RELEASE_GIL
     return 0;
 
 fail:
     Py_XDECREF(data);
+    _ZRAN_FILE_UTIL_RELEASE_GIL
     return -1;
 }
 
 /*
- * Implements a method analogous to fwrite that is performed on Python file-like objects.
+ * Implements a method analogous to fwrite that is performed on Python
+ * file-like objects.
  */
-size_t _fwrite_python(const void *ptr, size_t size, size_t nmemb, PyObject *f) {
+size_t _fwrite_python(const void *ptr,
+                      size_t      size,
+                      size_t      nmemb,
+                      PyObject   *f) {
+
     PyObject *input;
     PyObject *data = NULL;
-    long len;
+    long      len;
+
+    _ZRAN_FILE_UTIL_ACQUIRE_GIL
     if ((input = PyBytes_FromStringAndSize(ptr, size * nmemb)) == NULL)
         goto fail;
     if ((data = PyObject_CallMethod(f, "write", "(O)", input)) == NULL)
         goto fail;
+
     #if PY_MAJOR_VERSION >= 3
     if ((len = PyLong_AsLong(data)) == -1 && PyErr_Occurred())
         goto fail;
     #else
-    // In Python 2, a file object's write() method does not return the number of
-    // bytes written, so let's just assume that everything has been written properly.
+    // In Python 2, a file object's write() method does not return the number
+    // of bytes written, so let's just assume that everything has been written
+    // properly.
     len = size * nmemb;
     #endif
+
     Py_DECREF(input);
     Py_DECREF(data);
+    _ZRAN_FILE_UTIL_RELEASE_GIL
     return (size_t) len / size;
 
 fail:
     Py_XDECREF(input);
     Py_XDECREF(data);
+    _ZRAN_FILE_UTIL_RELEASE_GIL
     return 0;
 }
 
 /*
- * Implements a method analogous to getc that is performed on Python file-like objects.
+ * Implements a method analogous to getc that is performed on Python file-like
+ * objects.
  */
 int _getc_python(PyObject *f) {
     char buf;
@@ -155,28 +226,33 @@ int _getc_python(PyObject *f) {
  * Calls ferror on fd if specified, otherwise the Python-specific method on f.
  */
 int ferror_(FILE *fd, PyObject *f) {
-    return fd != NULL ? ferror(fd): _ferror_python(f);
+    return fd != NULL ? ferror(fd) : _ferror_python(f);
 }
 
 /*
  * Calls fseek on fd if specified, otherwise the Python-specific method on f.
  */
 int fseek_(FILE *fd, PyObject *f, int64_t offset, int whence) {
-    return fd != NULL ? FSEEK(fd, offset, whence): _fseek_python(f, offset, whence);
+    return fd != NULL
+        ? FSEEK(fd, offset, whence)
+        : _fseek_python(f, offset, whence);
 }
 
 /*
  * Calls ftell on fd if specified, otherwise the Python-specific method on f.
  */
 int64_t ftell_(FILE *fd, PyObject *f) {
-    return fd != NULL ? FTELL(fd): _ftell_python(f);
+    return fd != NULL ? FTELL(fd) : _ftell_python(f);
 }
 
 /*
  * Calls fread on fd if specified, otherwise the Python-specific method on f.
  */
 size_t fread_(void *ptr, size_t size, size_t nmemb, FILE *fd, PyObject *f) {
-    return fd != NULL ? fread(ptr, size, nmemb, fd): _fread_python(ptr, size, nmemb, f);
+
+  return fd != NULL
+      ? fread(ptr, size, nmemb, fd)
+      : _fread_python(ptr, size, nmemb, f);
 }
 
 /*
@@ -198,8 +274,14 @@ int fflush_(FILE *fd, PyObject *f) {
 /*
  * Calls fwrite on fd if specified, otherwise the Python-specific method on f.
  */
-size_t fwrite_(const void *ptr, size_t size, size_t nmemb, FILE *fd, PyObject *f) {
-    return fd != NULL ? fwrite(ptr, size, nmemb, fd): _fwrite_python(ptr, size, nmemb, f);
+size_t fwrite_(const void *ptr,
+               size_t      size,
+               size_t      nmemb,
+               FILE       *fd,
+               PyObject   *f) {
+    return fd != NULL
+        ? fwrite(ptr, size, nmemb, fd)
+        : _fwrite_python(ptr, size, nmemb, f);
 }
 
 /*

--- a/indexed_gzip/zran_file_util.h
+++ b/indexed_gzip/zran_file_util.h
@@ -4,8 +4,6 @@
 /*
  * File utilities used to manipulate either
  * Python file-like objects or file descriptors.
- *
- * Author: Paul McCarthy <pauldmccarthy@gmail.com>
  */
 
 #include <stdlib.h>

--- a/indexed_gzip/zran_file_util.h
+++ b/indexed_gzip/zran_file_util.h
@@ -13,42 +13,50 @@
 #include <Python.h>
 
 /*
- * Implements a method analogous to fread that is performed on Python file-like objects.
+ * Implements a method analogous to fread that is performed on Python
+ * file-like objects.
  */
 size_t _fread_python(void *ptr, size_t size, size_t nmemb, PyObject *f);
 
 /*
- * Implements a method analogous to ftell that is performed on Python file-like objects.
+ * Implements a method analogous to ftell that is performed on Python
+ * file-like objects.
  */
 int64_t _ftell_python(PyObject *f);
 
 /*
- * Implements a method analogous to fseek that is performed on Python file-like objects.
+ * Implements a method analogous to fseek that is performed on Python
+ * file-like objects.
  */
 int _fseek_python(PyObject *f, int64_t offset, int whence);
 
 /*
- * Implements a method analogous to feof that is performed on Python file-like objects.
+ * Implements a method analogous to feof that is performed on Python file-like
+ * objects.
  */
 int _feof_python(PyObject *f, size_t f_ret);
 
 /*
- * Implements a method analogous to ferror that is performed on Python file-like objects.
+ * Implements a method analogous to ferror that is performed on Python
+ * file-like objects.
  */
 int _ferror_python(PyObject *f);
 
 /*
- * Implements a method analogous to fflush that is performed on Python file-like objects.
+ * Implements a method analogous to fflush that is performed on Python
+ * file-like objects.
  */
 int _fflush_python(PyObject *f);
 
 /*
- * Implements a method analogous to fwrite that is performed on Python file-like objects.
+ * Implements a method analogous to fwrite that is performed on Python
+ * file-like objects.
  */
 size_t _fwrite_python(const void *ptr, size_t size, size_t nmemb, PyObject *f);
 
 /*
- * Implements a method analogous to getc that is performed on Python file-like objects.
+ * Implements a method analogous to getc that is performed on Python
+ * file-like objects.
  */
 int _getc_python(PyObject *f);
 
@@ -85,7 +93,8 @@ int fflush_(FILE *fd, PyObject *f);
 /*
  * Calls fwrite on fd if specified, otherwise the Python-specific method on f.
  */
-size_t fwrite_(const void *ptr, size_t size, size_t nmemb, FILE *fd, PyObject *f);
+size_t fwrite_(
+    const void *ptr, size_t size, size_t nmemb, FILE *fd, PyObject *f);
 
 /*
  * Calls getc on fd if specified, otherwise the Python-specific method on f.
@@ -93,4 +102,4 @@ size_t fwrite_(const void *ptr, size_t size, size_t nmemb, FILE *fd, PyObject *f
 int getc_(FILE *fd, PyObject *f);
 
 
-#endif /* __ZRAN_H__ */
+#endif /* __ZRAN_FILE_UTIL_H__ */

--- a/indexed_gzip/zran_file_util.pxd
+++ b/indexed_gzip/zran_file_util.pxd
@@ -1,8 +1,6 @@
 #
 # Cython declaration for the zran_file_util library.
 #
-# Author: Paul McCarthy <pauldmccarthy@gmail.com>
-#
 
 from libc.stdio  cimport FILE
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, int64_t


### PR DESCRIPTION
 * Change to the GIL management logic that was introduced in #55 - now, `IndexedGzipFile` will always release the GIL when calling a `zran` function. If a Python file-like is in use, the `zran_file_utils` functions will temporarily re-acquire and release the GIL as needed. 
 * Pickling/unpickling routines no longer require the use of temporary files - we can un/pickle directly from/to in memory file-likes.
 * Fix segmentation fault when an `IndexedGzipFile` is created with a path to a non-existent file (same error as #49)