### PR TITLE
Set PyErr_Occurred to a pointer, not an int

### DIFF
--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -137,7 +137,7 @@ int _feof_python(PyObject *f, size_t f_ret) {
  * file-like objects.
  */
 int _ferror_python(PyObject *f) {
-    int result;
+    PyObject *result;
 
     _ZRAN_FILE_UTIL_ACQUIRE_GIL
     result = PyErr_Occurred();


### PR DESCRIPTION
Fixes https://github.com/pauldmccarthy/indexed_gzip/issues/62