### PR TITLE
Fix wheels build on 32-bit machines

### DIFF
--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -15,8 +15,8 @@ export CIBW_ENVIRONMENT_WINDOWS="ZLIB_HOME='$ZLIB_HOME'"
 # cython for the Cython.Coverage plugin.
 export CIBW_TEST_REQUIRES="cython pytest pytest-cov coverage numpy nibabel"
 
-# Disable pypy and py27+win32bit builds
-export CIBW_SKIP="pp* cp27-win32"
+# Disable pypy builds
+export CIBW_SKIP="pp*"
 
 # Pytest makes it *very* awkward to run tests
 # from an installed package, and still find/


### PR DESCRIPTION
Fixes wheels building issues on 32-bit OSes.

We can't use PyObject_CallMethod with multiple arguments
because it causes tests with 32-bit OS wheels to fail,
(as the second argument is not passed correctly to Python),
so we have to manually build up the arguments in _fseek_python
instead.

When I was testing, it appears that, for example, passing `2` as the second argument
to `PyObject_CallMethod` (i.e., setting `whence` to 2) would end up coming out as a
`0` or `-1` on the Python size. Pretty bizarre.

We should probably eventually file an issue with cpython about this.

I tested building wheels with this fix in, and it appears to be working. Here's the GHA build: https://github.com/epicfaace/indexed_gzip/runs/2156959100