### PR TITLE
Perform CRC/size validation, and handle null padding bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
   `indexed_gzip` can still be loaded, but index files created with
   `indexed_gzip` 1.6.0 cannot be loaded by older versions of `indexed_gzip`
   (#75).
+* CRC and size validation of uncompressed data is now performed by default, on
+  the first pass through a GZIP file. This is not yet implemented when an
+  existing index is imported from file, and can be disabled by setting
+  the new `skip_crc_check` argument to `False` when creating an
+  `IndexedGzipFile` (#72).
+* Null padding bytes at the end of a GZIP file, or in between GZIP streams,
+  are now skipped over (#69, #70, #72).
 
 
 ## 1.5.3 (March 23rd 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # `indexed_gzip` changelog
 
 
-## 1.6.0 (..)
+## 1.6.0 (May 25th 2021)
 
 
 * Python 2.7 wheels for Windows are no longer being built (#71, 73).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@
   `indexed_gzip` can still be loaded, but index files created with
   `indexed_gzip` 1.6.0 cannot be loaded by older versions of `indexed_gzip`
   (#75).
-* CRC and size validation of uncompressed data is now performed by default, on
-  the first pass through a GZIP file. This is not yet implemented when an
-  existing index is imported from file, and can be disabled by setting
-  the new `skip_crc_check` argument to `False` when creating an
-  `IndexedGzipFile` (#72).
+* CRC and size validation of uncompressed data is now performed by default,
+  on the first pass through a GZIP file. This can be disabled by setting the
+  new `skip_crc_check` argument to `False` when creating an
+  `IndexedGzipFile`. Validation is not performed when an existing index is
+  imported from file (#72).
 * Null padding bytes at the end of a GZIP file, or in between GZIP streams,
   are now skipped over (#69, #70, #72).
+* Seek points are now created at the beginning of every GZIP stream, in files
+  containing concatenated streams (#72).
 
 
 ## 1.5.3 (March 23rd 2021)

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -19,4 +19,4 @@ versions of ``nibabel``.
 """
 
 
-__version__ = '1.5.3'
+__version__ = '1.6.0'

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -1059,7 +1059,7 @@ class ZranError(IOError):
     pass
 
 
-class CrcError(IOError):
+class CrcError(OSError):
     """Exception raised by the :class:`_IndexedGzipFile` when a CRC/size
     validation check fails, which suggests that the GZIP data might be
     corrupt.

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -587,8 +587,9 @@ cdef class _IndexedGzipFile:
         with self.__file_handle():
             ret = zran.zran_build_index(&self.index, 0, 0)
 
-        if ret != 0:
-            raise ZranError('zran_build_index returned error')
+        if ret != zran.ZRAN_BUILD_INDEX_OK:
+            raise ZranError('zran_build_index returned '
+                            'error: {}'.format(ret))
 
         log.debug('%s.build_full_index()', type(self).__name__)
 

--- a/indexed_gzip/tests/__init__.py
+++ b/indexed_gzip/tests/__init__.py
@@ -67,13 +67,11 @@ def compress(infile, outfile, buflen=-1):
 
         with open(infile, 'rb') as inf:
             while True:
-                with gzip.open(outfile, 'a') as outf:
-                    data = inf.read(buflen)
-
-                    if len(data) == 0:
-                        break
-
-                    outf.write(data)
+                data = inf.read(buflen)
+                if len(data) == 0:
+                    break
+                with open(outfile, 'ab') as outf:
+                    gzip.GzipFile(fileobj=outf).write(data)
 
     def compress_with_gzip_command():
 

--- a/indexed_gzip/tests/__init__.py
+++ b/indexed_gzip/tests/__init__.py
@@ -126,8 +126,7 @@ def compress(infile, outfile, buflen=-1):
 def compress_inmem(data, concat):
     """Compress the given data (assumed to be bytes) and return a bytearray
     containing the compressed data (including gzip header and footer).
-    Also returns offsets for the beginning of each separate stream (just [0]
-    if concat is False).
+    Also returns offsets for the end of each separate stream.
     """
 
     f = io.BytesIO()
@@ -136,14 +135,20 @@ def compress_inmem(data, concat):
 
     offsets    = []
     compressed = 0
+    print(f'Generating compressed data {len(data)}, concat: {concat})')
     while compressed < len(data):
-        cmpsize = len(f.getvalue())
-        chunk   = data[compressed:compressed + chunksize]
+        start = len(f.getvalue())
+        chunk = data[compressed:compressed + chunksize]
         with gzip.GzipFile(mode='ab', fileobj=f) as gzf:
             gzf.write(chunk)
 
-        offsets.append(cmpsize)
+        end = len(f.getvalue())
+
+        print(f'  Wrote stream to {start} - {end} [{end - start} bytes] ...')
+        offsets.append(end)
         compressed += chunksize
+
+    print(f'  Final size: {len(f.getvalue())}')
 
     f.seek(0)
     return bytearray(f.read()), offsets

--- a/indexed_gzip/tests/__init__.py
+++ b/indexed_gzip/tests/__init__.py
@@ -135,7 +135,8 @@ def compress_inmem(data, concat):
 
     offsets    = []
     compressed = 0
-    print(f'Generating compressed data {len(data)}, concat: {concat})')
+    print('Generating compressed data {}, concat: {})'.format(
+        len(data), concat))
     while compressed < len(data):
         start = len(f.getvalue())
         chunk = data[compressed:compressed + chunksize]
@@ -144,11 +145,12 @@ def compress_inmem(data, concat):
 
         end = len(f.getvalue())
 
-        print(f'  Wrote stream to {start} - {end} [{end - start} bytes] ...')
+        print('  Wrote stream to {} - {} [{} bytes] ...'.format(
+            start, end, end - start))
         offsets.append(end)
         compressed += chunksize
 
-    print(f'  Final size: {len(f.getvalue())}')
+    print('  Final size: {}'.format(len(f.getvalue())))
 
     f.seek(0)
     return bytearray(f.read()), offsets

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -381,11 +381,13 @@ def test_read_all(testfile, nelems, use_mmap, drop):
 
 def test_simple_read_with_null_padding():
 
-    with tempfile.NamedTemporaryFile() as file_in, tempfile.NamedTemporaryFile() as file_out:
-        file_in.write(b"hello world")
-        file_in.flush()
-        compress(file_in.name, file_out.name)
-        fileobj = BytesIO(open(file_out.name, "rb").read() + b"\0" * 100)
+
+    fileobj = BytesIO()
+
+    with gzip.GzipFile(fileobj=fileobj, mode='wb') as f:
+        f.write(b"hello world")
+
+    fileobj.write(b"\0" * 100)
 
     with igzip._IndexedGzipFile(fileobj=fileobj) as f:
         assert f.read() == b"hello world"

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -372,8 +372,12 @@ def test_read_all(testfile, nelems, use_mmap, drop):
 
 
 def test_simple_read_with_null_padding():
-
-    fileobj = BytesIO(gzip.compress(b"hello world") + b"\0" * 100)
+    
+    with tempfile.NamedTemporaryFile() as file_in, tempfile.NamedTemporaryFile() as file_out:
+        file_in.write(b"hello world")
+        file_in.flush()
+        compress(file_in.name, file_out.name)
+        fileobj = BytesIO(open(file_out.name, "rb").read() + b"\0" * 100)
     
     with igzip._IndexedGzipFile(fileobj=fileobj) as f:
         assert f.read() == b"hello world"

--- a/indexed_gzip/tests/ctest_zran.pyx
+++ b/indexed_gzip/tests/ctest_zran.pyx
@@ -1354,15 +1354,16 @@ def test_standard_usage_with_null_padding(concat):
     # into new padded compressed data
     padoff = 0  # offset into padded data
     last   = 0  # offset to end of last copied stream in unpadded data
-    print(f'Padding streams [orig size: {len(cmpdata)}] ...')
+    print('Padding streams [orig size: {}] ...'.format(len(cmpdata)))
     for off, pad in zip(strmoffs, padding):
 
         strm = cmpdata[last:off]
 
         paddedcmpdata[padoff:padoff + len(strm)] = strm
 
-        print(f'  Copied stream from [{last} - {off}] to '
-              f'[{padoff} - {padoff + len(strm)}] ({pad} padding bytes)')
+        print('  Copied stream from [{} - {}] to [{} - {}] ({} '
+              'padding bytes)'.format(
+                  last, off, padoff, padoff + len(strm), pad))
 
         padoff += len(strm) + pad
         last    = off

--- a/indexed_gzip/tests/ctest_zran.pyx
+++ b/indexed_gzip/tests/ctest_zran.pyx
@@ -35,6 +35,8 @@ from libc.stdio  cimport (SEEK_SET,
                           fdopen,
                           fwrite)
 
+from libc.stdint cimport int64_t
+
 from libc.string cimport memset, memcmp
 
 from cpython.exc cimport (PyErr_Clear,
@@ -52,7 +54,7 @@ from posix.mman cimport (mmap,
                          MAP_SHARED)
 
 
-from . import poll, check_data_valid, tempdir
+from . import poll, check_data_valid, tempdir, compress_inmem
 
 
 cdef extern from "sys/mman.h":
@@ -1022,6 +1024,7 @@ def test_readbuf_spacing_sizes(testfile, no_fds, nelems, niters, seed):
 
 cdef _compare_indexes(zran.zran_index_t *index1,
                       zran.zran_index_t *index2):
+    """Check that two indexes are equivalent. """
     cdef zran.zran_point_t *p1
     cdef zran.zran_point_t *p2
 
@@ -1048,8 +1051,10 @@ cdef _compare_indexes(zran.zran_index_t *index1,
             assert not memcmp(p2.data, p1.data, ws), msg
 
 
-
 def test_export_then_import(testfile, no_fds):
+    """Export-import round trip . Test exporting an index, then importing it
+    back in.
+    """
 
     cdef zran.zran_index_t index1
     cdef zran.zran_index_t index2
@@ -1099,6 +1104,9 @@ def test_export_then_import(testfile, no_fds):
 
 
 def test_export_import_no_points(no_fds):
+    """Test exporting and importing an index which does not contain any
+    seek points.
+    """
     cdef zran.zran_index_t index
     cdef void             *buffer
 
@@ -1189,6 +1197,7 @@ def test_export_import_format_v0():
 
 
 cdef _write_index_file_v0(zran.zran_index_t *index, dest):
+    """Write the given index out to a file, index file version 0 format. """
 
     cdef zran.zran_point_t *point
 
@@ -1210,3 +1219,110 @@ cdef _write_index_file_v0(zran.zran_index_t *index, dest):
             point = &index.list[i]
             data  = <bytes>point.data[:index.window_size]
             f.write(data)
+
+
+def test_crc_validation(concat):
+    """Basic test of CRC validation. """
+
+    cdef zran.zran_index_t index
+    cdef void             *buffer
+    cdef int64_t           ret
+
+    # use uint32 so there are lots of zeros,
+    # and so there is something to compress
+    dsize             = 1048576 * 10
+    data              = np.random.randint(0, 255, dsize // 4, dtype=np.uint32)
+    cmpdata, strmoffs = compress_inmem(data.tobytes(), concat)
+    buf               = ReadBuffer(dsize)
+    buffer            = buf.buffer
+    f                 = [None]  # to prevent gc
+
+    with open('crctest.gz', 'wb') as gf:
+        gf.write(cmpdata)
+
+    def _zran_init(flags):
+        f[0] = BytesIO(cmpdata)
+        assert not zran.zran_init(&index,
+                                  NULL,
+                                  <PyObject*>f[0],
+                                  1048576,
+                                  32768,
+                                  131072,
+                                  flags)
+
+    def _run_crc_tests(shouldpass, flags=zran.ZRAN_AUTO_BUILD):
+        if shouldpass:
+            expect_build = zran.ZRAN_BUILD_INDEX_OK
+            expect_seek  = zran.ZRAN_SEEK_OK
+            expect_read  = dsize
+        else:
+            expect_build = zran.ZRAN_BUILD_INDEX_CRC_ERROR
+            expect_seek  = zran.ZRAN_SEEK_CRC_ERROR
+            expect_read  = zran.ZRAN_READ_CRC_ERROR
+
+        # CRC validation should occur on the first
+        # pass through a gzip stream, regardless
+        # of how that pass is initiated. Below we
+        # test the most common scenarios.
+
+        # Error if we try to build an index.  Note
+        # that an error here is not guaranteed, as
+        # the _zran_expand_index might need a few
+        # passes through the data to reach the end,
+        # which might cause inflation to be
+        # re-initialised, and therefore validation
+        # to be disabled.  It depends on the data,
+        # and on the constants used in
+        # _zran_estimate_offset
+        _zran_init(flags)
+        ret = zran.zran_build_index(&index, 0, 0)
+        assert ret == expect_build, ret
+        zran.zran_free(&index)
+
+        # error if we try to seek
+        _zran_init(flags)
+        ret = zran.zran_seek(&index, dsize - 1, SEEK_SET, NULL)
+        assert ret == expect_seek, ret
+        zran.zran_free(&index)
+
+        # error if we try to read
+        _zran_init(flags)
+        ret = zran.zran_read(&index, buffer, dsize)
+        assert ret == expect_read, ret
+        zran.zran_free(&index)
+
+        if shouldpass:
+            pybuf = <bytes>(<char *>buffer)[:dsize]
+            assert np.all(np.frombuffer(pybuf, dtype=np.uint32) == data)
+
+    # data/crc is good, all should be well
+    _run_crc_tests(True)
+
+    # corrupt the size, we should get an error
+    cmpdata[-1] += 1  # corrupt size
+    _run_crc_tests(False)
+
+    # corrupt the crc, we should get an error
+    cmpdata[-1] -= 1  # restore size to correct value
+    cmpdata[-5] += 1  # corrupt crc
+    _run_crc_tests(False)
+
+    # Corrupt a different stream, if we have more than one
+    cmpdata[-5] -= 1  # restore crc to correct value
+    if len(strmoffs) > 1:
+        for off in strmoffs[1:]:
+            cmpdata[off-1] += 1
+            _run_crc_tests(False)
+            cmpdata[off-1] -= 1
+
+    # Disable CRC, all should be well, even with a corrupt CRC/size
+    # First test with good data
+    _run_crc_tests(True, zran.ZRAN_AUTO_BUILD | zran.ZRAN_SKIP_CRC_CHECK)
+
+    cmpdata[-1] += 1  # corrupt size
+    _run_crc_tests(True, zran.ZRAN_AUTO_BUILD | zran.ZRAN_SKIP_CRC_CHECK)
+
+    cmpdata[-1] -= 1  # restore size to correct value
+    cmpdata[-5] -= 1  # corrupt crc
+    _run_crc_tests(True, zran.ZRAN_AUTO_BUILD | zran.ZRAN_SKIP_CRC_CHECK)
+

--- a/indexed_gzip/tests/ctest_zran.pyx
+++ b/indexed_gzip/tests/ctest_zran.pyx
@@ -799,13 +799,14 @@ def test_seek_then_read_block(testfile, no_fds, nelems, niters, seed, use_mmap):
     with open(testfile, 'rb') as pyfid:
         cfid = fdopen(pyfid.fileno(), 'rb')
 
-        assert not zran.zran_init(&index,
-                                  NULL if no_fds else cfid,
-                                  <PyObject*>pyfid if no_fds else NULL,
-                                  indexSpacing,
-                                  32768,
-                                  131072,
-                                  zran.ZRAN_AUTO_BUILD)
+        ret = zran.zran_init(&index,
+                             NULL if no_fds else cfid,
+                             <PyObject*>pyfid if no_fds else NULL,
+                             indexSpacing,
+                             32768,
+                             131072,
+                             zran.ZRAN_AUTO_BUILD)
+        assert not ret, ret
 
         for i, se in enumerate(seekelems):
 

--- a/indexed_gzip/tests/test_indexed_gzip.py
+++ b/indexed_gzip/tests/test_indexed_gzip.py
@@ -160,7 +160,7 @@ def test_import_export_index():
 def test_wrapper_class():
     ctest_indexed_gzip.test_wrapper_class()
 
-def test_size_multiple_of_readbuf():
+def test_size_multiple_of_readbuf(seed):
     ctest_indexed_gzip.test_size_multiple_of_readbuf()
 
 @pytest.mark.slow_test

--- a/indexed_gzip/tests/test_indexed_gzip.py
+++ b/indexed_gzip/tests/test_indexed_gzip.py
@@ -82,6 +82,12 @@ def test_read_all(testfile, nelems, use_mmap):
 def test_read_all_drop_handles(testfile, nelems, use_mmap):
     ctest_indexed_gzip.test_read_all(testfile, nelems, use_mmap, True)
 
+def test_simple_read_with_null_padding():
+    ctest_indexed_gzip.test_simple_read_with_null_padding()
+
+def test_read_with_null_padding(testfile, nelems):
+    ctest_indexed_gzip.test_read_with_null_padding(testfile, nelems)
+
 def test_read_beyond_end(concat):
     ctest_indexed_gzip.test_read_beyond_end(concat, False)
 

--- a/indexed_gzip/tests/test_zran.py
+++ b/indexed_gzip/tests/test_zran.py
@@ -124,3 +124,6 @@ if not sys.platform.startswith("win"):
 
     def test_crc_validation(concat):
         ctest_zran.test_crc_validation(concat)
+
+    def test_standard_usage_with_null_padding(concat):
+        ctest_zran.test_standard_usage_with_null_padding(concat)

--- a/indexed_gzip/tests/test_zran.py
+++ b/indexed_gzip/tests/test_zran.py
@@ -121,3 +121,6 @@ if not sys.platform.startswith("win"):
 
     def test_export_import_format_v0():
         ctest_zran.test_export_import_format_v0()
+
+    def test_crc_validation(concat):
+        ctest_zran.test_crc_validation(concat)

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1423,8 +1423,9 @@ int _zran_find_next_stream(zran_index_t *index,
                            int          *offset) {
 
 
-    int ret;
-    int found;
+    uint64_t i;
+    int      ret;
+    int      found;
 
     /*
      * Search for the beginning of
@@ -1433,27 +1434,30 @@ int _zran_find_next_stream(zran_index_t *index,
      */
     found = 0;
 
-    zran_log("Searching for a new stream\n");
+    zran_log("Searching for a new stream [%u]\n", stream->avail_in);
 
-    while (stream->avail_in >= 2) {
+    while (stream->avail_in > 0) {
 
-        if (stream->next_in[0] == 0x1f &&
+        if (stream->avail_in   >= 2    &&
+            stream->next_in[0] == 0x1f &&
             stream->next_in[1] == 0x8b) {
             found = 1;
             break;
         }
 
-        *offset          += 2;
-        stream->next_in  += 2;
-        stream->avail_in -= 2;
+        *offset          += 1;
+        stream->next_in  += 1;
+        stream->avail_in -= 1;
     }
 
     /*
      * No header found for
      * the next stream.
      */
-    if (found == 0)
+    if (found == 0) {
+        zran_log("Could not find another stream [%u]\n", stream->avail_in);
         goto not_found;
+    }
 
     zran_log("New stream found, re-initialising inflation\n");
 

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1289,7 +1289,7 @@ static int _zran_validate_stream(zran_index_t *index,
 
     stream->avail_in -= 8;
     stream->next_in  += 8;
-    *offset           = 8;
+    *offset          += 8;
 
     if (index->stream_crc32 != crc || index->stream_size != size) {
         return ZRAN_VALIDATE_STREAM_INVALID;
@@ -1643,7 +1643,7 @@ static int _zran_inflate(zran_index_t *index,
                 // todo only validate on first pass
                 /*
                  * Check that the CRC and uncompressed size in
-                 * the fotoer match what we have calculated
+                 * the footer match what we have calculated
                  */
                 z_ret = _zran_validate_stream( index, strm, &off);
 
@@ -1677,7 +1677,7 @@ static int _zran_inflate(zran_index_t *index,
 
             /*
              * Initialise counters to calculate
-             * how many bytes are input/uutput
+             * how many bytes are input/output
              * during this call to inflate.
              */
             bytes_consumed = strm->avail_in;
@@ -2813,6 +2813,8 @@ int zran_import_index(zran_index_t *index,
     uint32_t      window_size;
     uint32_t      npoints;
     zran_point_t *new_list = NULL;
+
+    // todo apply skip crc check flag
 
     /* Check if file is read only. */
     if (!is_readonly(fd, f)) goto fail;

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -2274,10 +2274,10 @@ int zran_seek(zran_index_t  *index,
      */
     result = _zran_get_point_with_expand(index, offset, 0, &seek_point);
 
-    if (result == ZRAN_GET_POINT_CRC_ERROR)   goto crcerror;
-    if (result == ZRAN_GET_POINT_FAIL)        goto fail;
-    if (result == ZRAN_GET_POINT_NOT_COVERED) goto not_covered;
-    if (result == ZRAN_GET_POINT_EOF)         goto eof;
+    if      (result == ZRAN_GET_POINT_EOF)         goto eof;
+    else if (result == ZRAN_GET_POINT_NOT_COVERED) goto not_covered;
+    else if (result == ZRAN_GET_POINT_CRC_ERROR)   goto crcerror;
+    else if (result != ZRAN_GET_POINT_OK)          goto fail;
 
     index->uncmp_seek_offset = offset;
     offset                   = seek_point->cmp_offset;
@@ -2411,8 +2411,10 @@ int64_t zran_read(zran_index_t *index,
 
     if (ret == ZRAN_GET_POINT_EOF)         goto eof;
     if (ret == ZRAN_GET_POINT_NOT_COVERED) goto not_covered;
-    if (ret == ZRAN_GET_POINT_CRC_ERROR) {
-        error_return_val = ZRAN_READ_CRC_ERROR;
+    else if (ret != ZRAN_GET_POINT_OK) {
+        if (ret == ZRAN_GET_POINT_CRC_ERROR) {
+            error_return_val = ZRAN_READ_CRC_ERROR;
+        }
         goto fail;
     }
 

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1467,11 +1467,26 @@ static int _zran_inflate(zran_index_t *index,
             }
 
             /*
-             * No bytes read - we've reached EOF
+             * No bytes left to read -
+             * we've reached EOF
              */
             if (f_ret == 0) {
                 if (feof_(index->fd, index->f, f_ret)) {
+
+                    zran_log("End of file, stopping inflation\n");
+
                     return_val = ZRAN_INFLATE_EOF;
+
+                    /*
+                     * We now know how big the
+                     * uncompressed data is.
+                     */
+                    if (index->uncompressed_size == 0) {
+
+                        zran_log("Updating uncompressed data "
+                                 "size: %llu\n", uncmp_offset);
+                        index->uncompressed_size = uncmp_offset;
+                    }
                     break;
                 }
                 /*
@@ -1665,27 +1680,9 @@ static int _zran_inflate(zran_index_t *index,
              * the end of a file, and this
              * won't happen when the file
              * size is an exact multiple of
-             # the read buffer size.
+             * the read buffer size.
              */
-            if ((uint64_t) ftell_(index->fd, index->f) >= index->compressed_size &&
-                strm->avail_in <= 8) {
 
-                zran_log("End of file, stopping inflation\n");
-
-                return_val = ZRAN_INFLATE_EOF;
-
-                /*
-                 * We now know how big the
-                 * uncompressed data is.
-                 */
-                if (index->uncompressed_size == 0) {
-
-                    zran_log("Updating uncompressed data "
-                             "size: %llu\n", uncmp_offset);
-                    index->uncompressed_size = uncmp_offset;
-                }
-                break;
-            }
 
             /*
              * Some of the code above has decided that

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1329,10 +1329,22 @@ static int _zran_read_data_from_file(zran_index_t *index,
     /*
      * If there are any unprocessed bytes
      * left over, put them at the beginning
-     * of the read buffer
+     * of the read buffer.
+     *
+     * TODO: In times gone by, we would only
+     * attempt to read data (and therefore
+     * rotate memory here) when the read
+     * buffer was empty. But now, to keep
+     * the code in _zran_inflate clean-ish),
+     * we do this repeatedly, even when we
+     * are at EOF, to ensure that there is
+     * enough data to validate one stream,
+     * and find the next. We could improve
+     * things here, by only rotating memory
+     * here if needed.
      */
     if (stream->avail_in > 0) {
-        memcpy(index->readbuf, stream->next_in, stream->avail_in);
+        memmove(index->readbuf, stream->next_in, stream->avail_in);
     }
 
     zran_log("Reading from file %llu [== %llu?] "

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -849,7 +849,12 @@ int _zran_get_point_with_expand(zran_index_t  *index,
      */
     result = _zran_get_point_at(index, offset, compressed, point);
 
-    if ((index->flags & ZRAN_AUTO_BUILD) == 0) {
+    /*
+     * Don't expand the index if auto_build
+     * is not active, unless the requested
+     * offset is the beginning of the file.
+     */
+    if ((offset > 0) && ((index->flags & ZRAN_AUTO_BUILD) == 0)) {
         return result;
     }
 

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1988,7 +1988,7 @@ int _zran_expand_index(zran_index_t *index, uint64_t until)
          * or at a compress block boundary,
          * and index->spacing bytes have passed
          * since the last index point that was
-         * created, we'll create a  new index
+         * created, we'll create a new index
          * point at this location.
          */
         if (z_ret == ZRAN_INFLATE_EOF ||

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -2862,7 +2862,8 @@ int zran_import_index(zran_index_t *index,
     uint32_t      npoints;
     zran_point_t *new_list = NULL;
 
-    // todo apply skip crc check flag
+    /* CRC validation is currently not possible on an imported index */
+    index->flags |= ZRAN_SKIP_CRC_CHECK;
 
     /* Check if file is read only. */
     if (!is_readonly(fd, f)) goto fail;

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1203,6 +1203,7 @@ int _zran_init_zlib_inflate(zran_index_t *index,
                  "seek location (expecting GZIP header)\n");
         if (inflateInit2(stream, windowBits + 32) != Z_OK) { goto fail; }
         if (inflate(stream, Z_BLOCK)              != Z_OK) { goto fail; }
+        if (inflateEnd(stream)                    != Z_OK) { goto fail; }
     }
 
     /*
@@ -1440,8 +1441,9 @@ int _zran_find_next_stream(zran_index_t *index,
      * Re-configure for inflation
      * from the new stream.
      */
-    if (inflateEnd(stream) != Z_OK)
+    if (inflateEnd(stream) != Z_OK) {
         goto fail;
+    }
 
     ret = _zran_init_zlib_inflate(index, stream, NULL);
 

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1422,10 +1422,8 @@ int _zran_find_next_stream(zran_index_t *index,
                            z_stream     *stream,
                            int          *offset) {
 
-
-    uint64_t i;
-    int      ret;
-    int      found;
+    int ret;
+    int found;
 
     /*
      * Search for the beginning of

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1205,6 +1205,13 @@ int _zran_init_zlib_inflate(zran_index_t *index,
         if (inflateInit2(stream, windowBits + 32) != Z_OK) { goto fail; }
         if (inflate(stream, Z_BLOCK)              != Z_OK) { goto fail; }
         if (inflateEnd(stream)                    != Z_OK) { goto fail; }
+
+        /*
+         * Reset CRC/size validation counters when
+         * we start reading a new gzip stream
+         */
+        index->stream_size  = 0;
+        index->stream_crc32 = 0;
     }
 
     /*
@@ -1452,12 +1459,6 @@ int _zran_find_next_stream(zran_index_t *index,
     }
 
     *offset += ret;
-
-    /*
-     * Reset stream size/crc counters
-     */
-    index->stream_size  = 0;
-    index->stream_crc32 = 0;
 
     return 0;
 

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -22,9 +22,10 @@
 #include "io.h"
 static int is_readonly(FILE *fd, PyObject *f)
 {
-    /* Can't find a way to do this correctly under Windows and
-       the check is not required anyway since the underlying
-       Python module checks it already */
+    /* Can't find a way to do this correctly under
+       Windows and the check is not required anyway
+       since the underlying Python module checks it
+       already */
     return 1;
 }
 #else
@@ -599,17 +600,34 @@ int zran_init(zran_index_t *index,
     if (readbuf_size == 0) readbuf_size = 16384;
 
     /*
-     * The zlib manual specifies that a window size of 32KB is 'always enough'
-     * to initialise inflation/deflation with a set dictionary. Less than
-     * that is not guaranteed to be enough.
-    */
+     * The zlib manual specifies that a window
+     * size of 32KB is 'always enough' to
+     * initialise inflation/deflation with a
+     * set dictionary. Less than that is not
+     * guaranteed to be enough.
+     */
     if (window_size < 32768)
         goto fail;
 
     /*
-     * window_size bytes of uncompressed data are stored with each seek point
-     * in the index. So it's a bit silly to have the distance between
-     * consecutive points less than the window size.
+     * Small read-buffers make code complicated.
+     * The absolute minimum we need is enough to
+     * store a GZIP footer, null padding bytes at
+     * the end of a stream, and the subsequent
+     * GZIP header. There are no bounds on the
+     * number of padding bytes, or the size of a
+     * GZIP header, so this constraint is
+     * arbitrary (but should be good enough).
+     */
+    if (readbuf_size < 512)
+        goto fail;
+
+    /*
+     * window_size bytes of uncompressed data are
+     * stored with each seek point in the index.
+     * So it's a bit silly to have the distance
+     * between consecutive points less than the
+     * window size.
      */
     if (spacing <= window_size)
       goto fail;

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1188,10 +1188,10 @@ int _zran_init_zlib_inflate(zran_index_t *index,
                             z_stream     *stream,
                             zran_point_t *point) {
 
-    int     ret;
-    int     windowBits;
-    int64_t seek_loc;
-    int     bytes_read;
+    int           ret;
+    int           windowBits;
+    int64_t       seek_loc;
+    unsigned long bytes_read;
 
     bytes_read     = stream->avail_in;
     windowBits     = index->log_window_size;
@@ -1255,7 +1255,7 @@ int _zran_init_zlib_inflate(zran_index_t *index,
      * the inflation dictionary from the uncompressed
      * data associated with the index point.
      */
-    if (point != NULL) {
+    if (point != NULL && point->data != NULL) {
 
         /*
          * The starting index point is not byte-aligned,
@@ -1280,12 +1280,10 @@ int _zran_init_zlib_inflate(zran_index_t *index,
          * Initialise the inflate stream
          * with the index point data.
          */
-        if (point->data != NULL) {
-            if (inflateSetDictionary(stream,
-                                     point->data,
-                                     index->window_size) != Z_OK)
-                goto fail;
-        }
+        if (inflateSetDictionary(stream,
+                                 point->data,
+                                 index->window_size) != Z_OK)
+            goto fail;
     }
 
     /*
@@ -1335,7 +1333,7 @@ static int _zran_read_data_from_file(zran_index_t *index,
      * attempt to read data (and therefore
      * rotate memory here) when the read
      * buffer was empty. But now, to keep
-     * the code in _zran_inflate clean-ish),
+     * the code in _zran_inflate clean-ish,
      * we do this repeatedly, even when we
      * are at EOF, to ensure that there is
      * enough data to validate one stream,
@@ -1946,11 +1944,11 @@ static int _zran_inflate(zran_index_t *index,
             }
 
             /*
-             * We've found the end of file, or end of
-             * one gzip stream. Validate the uncompressed
+             * We've found the end of file, or end of one
+             * gzip stream. Validate the uncompressed
              * data (size/ CRC) against the gzip footer.
-             * Then then search for a new stream and, if
-             * we find one, re-initialise inflation
+             * Then search for a new stream and, if we
+             * find one, re-initialise inflation
              */
             if (z_ret == Z_STREAM_END) {
 
@@ -1966,7 +1964,7 @@ static int _zran_inflate(zran_index_t *index,
                  * There is no way of knowing how much data we
                  * need to read in here - there is no upper
                  * bound on the amount of null padding bytes
-                 * that may be present in betweem, or at the
+                 * that may be present in between, or at the
                  * end of, a stream, and there is no upper
                  * bound on the size of a gzip header.
 
@@ -2428,7 +2426,7 @@ int _zran_expand_index(zran_index_t *index, uint64_t until) {
          * of the file, and at the beginning of all
          * other gzip streams, in the case of
          * concatenated streams (refer to its
-         * add_stream_points argument),
+         * add_stream_points argument).
          */
         if (z_ret == ZRAN_INFLATE_EOF ||
             uncmp_offset - last_uncmp_offset >= index->spacing) {

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -2349,6 +2349,15 @@ int _zran_expand_index(zran_index_t *index, uint64_t until) {
         data_offset   = (data_offset + bytes_output) % data_size;
 
         /*
+         * update the last created offset on every iteration,
+         * to catch any index points created by _zran_inflate
+         */
+        if (index->npoints > 0) {
+            last_created      = &index->list[index->npoints - 1];
+            last_uncmp_offset = last_created->uncmp_offset;
+        }
+
+        /*
          * Has the output buffer been filled?
          * If so, we just continue - the
          * data_offset trickery means that we
@@ -2398,9 +2407,6 @@ int _zran_expand_index(zran_index_t *index, uint64_t until) {
                                 data) != 0) {
                 goto fail;
             }
-
-            last_created      = &index->list[index->npoints - 1];
-            last_uncmp_offset = uncmp_offset;
         }
 
         /* And if at EOF, we are done. */

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -244,7 +244,12 @@ static int _zran_init_zlib_inflate(
 );
 
 
-/* Return codes for _zran_expand_index */
+/*
+ * Return codes for _zran_expand_index. These are currently
+ * assumed to have identical values to the ZRAN_BUILD_INDEX
+ * return codes.
+ */
+int ZRAN_EXPAND_INDEX_OK        =  0;
 int ZRAN_EXPAND_INDEX_FAIL      = -1;
 int ZRAN_EXPAND_INDEX_CRC_ERROR = -2;
 
@@ -811,7 +816,7 @@ int zran_build_index(zran_index_t *index, uint64_t from, uint64_t until)
 {
 
     if (_zran_invalidate_index(index, from) != 0)
-        return -1;
+        return ZRAN_BUILD_INDEX_FAIL;
 
     if (until == 0)
       until = index->compressed_size;
@@ -971,6 +976,9 @@ int _zran_get_point_with_expand(zran_index_t  *index,
         limit = _zran_index_limit(index, 1);
         if (expand <= limit)
             expand = limit + 10;
+
+        zran_log("Estimated mapping from uncompresseed offset "
+                 "%lu into compressed data: %lu\n", offset, expand);
 
         /*
          * Expand the index
@@ -2437,7 +2445,7 @@ int _zran_expand_index(zran_index_t *index, uint64_t until) {
              cmp_offset, last_created->cmp_offset);
 
     free(data);
-    return 0;
+    return ZRAN_EXPAND_INDEX_OK;
 
 fail:
     free(data);

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -257,13 +257,24 @@ void zran_free(
   zran_index_t *index /* The index */
 );
 
+/*
+ * Return codes for zran_build_index.
+ */
+enum {
+    ZRAN_BUILD_INDEX_OK        =  0,
+    ZRAN_BUILD_INDEX_FAIL      = -1,
+    ZRAN_BUILD_INDEX_CRC_ERROR = -2,
+};
+
 
 /*
  * (Re-)Builds the index to cover the given range, which must be
  * specified relative to the compressed data stream. Pass in 0
  * for both offsets to re-build the full index.
  *
- * Returns 0 on success, non-0 on failure.
+ * Returns ZRAN_BUILD_INDEX_OK on success, ZRAN_BUILD_INDEX_CRC_ERROR
+ * if a CRC error is detected in a GZIP stream, or ZRAN_BUILD_INDEX_FAIL
+ * if some other type of error occurs.
  */
 int zran_build_index(
   zran_index_t *index, /* The index */

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -222,7 +222,10 @@ struct _zran_point {
  *
  * The read buffer must be at least the maximum expectedd size of a GZIP
  * header. GZIP headers have a minimum size of 10 bytes, but there is no upper
- * bound on their size, so using a very small read buffer would be unwise.
+ * bound on their size, so using a very small read buffer would be unwise.  In
+ * the case of concatenated GZIP streams, the read buffer must be at least big
+ * enough to accommodate a GZIP footer of one stream, padding bytes in between
+ * two streams, and the GZIP header of the next stream.
  *
  * The flags argument is a bit mask used to control the following options:
  *

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -154,8 +154,11 @@ struct _zran_index {
      * against the CRC and size in the gzip
      * footer, and an error is returned if
      * they don't match.
+     *
+     * (the zlib crc32 function returns
+     * an unsigned long, so we use u64)
      */
-    uint32_t      stream_crc32;
+    uint64_t      stream_crc32;
     uint32_t      stream_size;
 };
 

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -40,60 +40,61 @@ struct _zran_index {
     /*
      * Handle to the compressed file.
      */
-    FILE         *fd;
+    FILE *fd;
 
     /*
      * Handle to the compressed file object.
      */
-    PyObject     *f;
+    PyObject *f;
 
     /*
      * Size of the compressed file. This
      * is calculated in zran_init.
      */
-    uint64_t      compressed_size;
+    uint64_t compressed_size;
 
     /*
      * Size of the uncompressed data. This is
      * only updated when it becomes known.
      */
-    uint64_t      uncompressed_size;
+    uint64_t uncompressed_size;
 
     /*
      * Spacing size in bytes, relative to the
      * uncompressed data stream, between adjacent
      * index points.
      */
-    uint32_t      spacing;
+    uint32_t spacing;
 
     /*
      * Number of bytes of uncompressed data to store
      * for each index point. This must be a minimum
      * of 32768 bytes.
      */
-    uint32_t      window_size;
+    uint32_t window_size;
 
     /*
      * Base2 logarithm of the window size - it
      * is needed to initialise zlib inflation.
      */
-    uint32_t      log_window_size;
+    uint32_t log_window_size;
 
     /*
      * Size, in bytes, of buffer used to store
      * compressed data read from disk.
      */
-    uint32_t      readbuf_size;
+    uint32_t readbuf_size;
 
     /*
      * Number of index points that have been created.
      */
-    uint32_t      npoints;
+    uint32_t npoints;
 
     /*
-     * Number of index points that can be stored.
+     * Number of index points that can be stored -
+     * i.e. the amount allocated to the "list" field.
      */
-    uint32_t      size;
+    uint32_t size;
 
     /*
      * List of index points.
@@ -107,12 +108,12 @@ struct _zran_index {
      * of where the calling code thinks it
      * is in the (uncompressed) file.
      */
-    uint64_t      uncmp_seek_offset;
+    uint64_t uncmp_seek_offset;
 
     /*
      * Flags passed to zran_init
      */
-    uint16_t      flags;
+    uint16_t flags;
 
     /*
      * All of the fields after this point are used
@@ -123,25 +124,24 @@ struct _zran_index {
      * Reference to a file input
      * buffer of size readbuf_size.
      */
-    uint8_t      *readbuf;
+    uint8_t *readbuf;
 
     /*
      * An offset into readbuf.
      */
-    uint32_t      readbuf_offset;
+    uint32_t readbuf_offset;
 
     /*
      * The current end of the readbuf contents.
      */
-    uint32_t      readbuf_end;
+    uint32_t readbuf_end;
 
     /*
      * Current offsets into the uncompressed and
      * compressed data streams.
      */
-    uint64_t      inflate_cmp_offset;
-    uint64_t      inflate_uncmp_offset;
-
+    uint64_t inflate_cmp_offset;
+    uint64_t inflate_uncmp_offset;
 
     /*
      * Total number of bytes that have been
@@ -150,8 +150,7 @@ struct _zran_index {
      * gotten to so far. This is updated as
      * more data is read and uncompressed.
      */
-    uint64_t      uncompressed_seen;
-
+    uint64_t uncompressed_seen;
 
     /*
      * CRC-32 checksum and size (number of
@@ -169,8 +168,8 @@ struct _zran_index {
      * (the zlib crc32 function returns
      * an unsigned long, so we use u64)
      */
-    uint64_t      stream_crc32;
-    uint32_t      stream_size;
+    uint64_t stream_crc32;
+    uint32_t stream_size;
 };
 
 

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -144,13 +144,14 @@ struct _zran_index {
     uint64_t inflate_uncmp_offset;
 
     /*
-     * Total number of bytes that have been
-     * uncompressed so far - the farthest point
-     * in the uncompressed data that we have
-     * gotten to so far. This is updated as
-     * more data is read and uncompressed.
+     * Uncompressed offset at the point that the
+     * last GZIP stream ended. This is updated as
+     * more data is read and uncompressed, and
+     * used to determine whether the CRC/size
+     * check for the current stream has already
+     * been performed.
      */
-    uint64_t uncompressed_seen;
+    uint64_t last_stream_ended;
 
     /*
      * CRC-32 checksum and size (number of

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -142,6 +142,17 @@ struct _zran_index {
     uint64_t      inflate_cmp_offset;
     uint64_t      inflate_uncmp_offset;
 
+
+    /*
+     * Total number of bytes that have been
+     * uncompressed so far - the farthest point
+     * in the uncompressed data that we have
+     * gotten to so far. This is updated as
+     * more data is read and uncompressed.
+     */
+    uint64_t      uncompressed_seen;
+
+
     /*
      * CRC-32 checksum and size (number of
      * bytes, modulo 2^32) of the uncompressed

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -227,6 +227,8 @@ struct _zran_point {
  *
  *     ZRAN_SKIP_CRC_CHECK: Do not perform a CRC32 and file size check
  *                          when the end of a GZIP stream is reached.
+ *                          This flag is automatically set when an index
+ *                          is imported from file using zran_import_index.
  */
 int  zran_init(
   zran_index_t *index,        /* The index                                  */
@@ -445,6 +447,10 @@ enum {
  *
  * Updating an index file is not supported currently. To update an index file,
  * first import it, create new checkpoints, and then export it again.
+ *
+ * CRC validation of uncompressed data from an imported index is not currently
+ * supported - this function will enable the ZRAN_SKIP_CRC_CHECK flag on the
+ * given zran_index_t struct.
  *
  * See zran_export_index for exporting.
  *

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -267,6 +267,7 @@ int zran_build_index(
 
 /* Return codes for zran_seek. */
 enum {
+    ZRAN_SEEK_CRC_ERROR       = -2,
     ZRAN_SEEK_FAIL            = -1,
     ZRAN_SEEK_OK              =  0,
     ZRAN_SEEK_NOT_COVERED     =  1,
@@ -297,6 +298,10 @@ enum {
  *    - ZRAN_SEEK_EOF to indicate that the requested offset
  *      is past the end of the uncompressed stream.
  *
+ *    - ZRAN_SEEK_CRC_ERROR to indicate that the CRC or file size
+ *      stored in the footer of a GZIP stream does not match the
+ *      data.
+ *
  *    - ZRAN_SEEK_FAIL to indicate failure of some sort.
  */
 int zran_seek(
@@ -320,7 +325,8 @@ uint64_t zran_tell(
 enum {
     ZRAN_READ_NOT_COVERED = -1,
     ZRAN_READ_EOF         = -2,
-    ZRAN_READ_FAIL        = -3
+    ZRAN_READ_FAIL        = -3,
+    ZRAN_READ_CRC_ERROR   = -4
 };
 
 /*
@@ -337,6 +343,10 @@ enum {
  *
  *   - ZRAN_READ_EOF to indicate that the read could not be completed
  *     because the current uncompressed seek point is at EOF.
+ *
+ *   - ZRAN_SEEK_CRC_ERROR to indicate that the CRC or file size
+ *     stored in the footer of a GZIP stream does not match the
+ *     data.
  *
  *   - ZRAN_READ_FAIL to indicate that the read failed for some reason.
  */

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -26,8 +26,8 @@ typedef struct _zran_point zran_point_t;
  * They are specified as bit-masks, rather than bit locations.
  */
 enum {
-  ZRAN_AUTO_BUILD = 1,
-
+  ZRAN_AUTO_BUILD     = 1,
+  ZRAN_SKIP_CRC_CHECK = 2,
 };
 
 
@@ -141,6 +141,22 @@ struct _zran_index {
      */
     uint64_t      inflate_cmp_offset;
     uint64_t      inflate_uncmp_offset;
+
+    /*
+     * CRC-32 checksum and size (number of
+     * bytes, modulo 2^32) of the uncompressed
+     * data in the current gzip stream, not
+     * used if ZRAN_SKIP_CRC_CHECK is active.
+     * The CRC and size are incrementally
+     * calculated as data is read in. When the
+     * end of a gzip stream is reached, the
+     * calculated CRC and size are compared
+     * against the CRC and size in the gzip
+     * footer, and an error is returned if
+     * they don't match.
+     */
+    uint32_t      stream_crc32;
+    uint32_t      stream_size;
 };
 
 
@@ -194,7 +210,10 @@ struct _zran_point {
  *
  * The flags argument is a bit mask used to control the following options:
  *
- *     ZRAN_AUTO_BUILD: Build the index automatically on demand.
+ *     ZRAN_AUTO_BUILD:     Build the index automatically on demand.
+ *
+ *     ZRAN_SKIP_CRC_CHECK: Do not perform a CRC32 and file size check
+ *                          when the end of a GZIP stream is reached.
  */
 int  zran_init(
   zran_index_t *index,        /* The index                                  */

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -335,7 +335,8 @@ enum {
  * the ZRAN_AUTO_BUILD flag, it is expanded as needed.
  *
  * Returns:
- *   - Number of bytes read for success.
+ *   - Number of bytes read for success, or one of the following codes,
+ *     all of which are negative.
  *
  *   - ZRAN_READ_NOT_COVERED to indicate that the index does not
  *     cover the requested region (will never happen if

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -171,6 +171,7 @@ struct _zran_index {
      */
     uint64_t stream_crc32;
     uint32_t stream_size;
+    uint8_t  validating;
 };
 
 

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -215,11 +215,15 @@ struct _zran_point {
  * Initialise a zran_index_t struct for use with the given file.
  *
  * Passing in 0 for the spacing, window_size and readbuf_size arguments
- * will result in the follwoing values being used:
+ * will result in the following values being used:
  *
  *    spacing:      1048576
  *    window_size:  32768
  *    readbuf_size: 16384
+ *
+ * The read buffer must be at least the maximum expectedd size of a GZIP
+ * header. GZIP headers have a minimum size of 10 bytes, but there is no upper
+ * bound on their size, so using a very small read buffer would be unwise.
  *
  * The flags argument is a bit mask used to control the following options:
  *

--- a/indexed_gzip/zran.h
+++ b/indexed_gzip/zran.h
@@ -165,11 +165,8 @@ struct _zran_index {
      * against the CRC and size in the gzip
      * footer, and an error is returned if
      * they don't match.
-     *
-     * (the zlib crc32 function returns
-     * an unsigned long, so we use u64)
      */
-    uint64_t stream_crc32;
+    uint32_t stream_crc32;
     uint32_t stream_size;
     uint8_t  validating;
 };

--- a/indexed_gzip/zran.pxd
+++ b/indexed_gzip/zran.pxd
@@ -28,9 +28,16 @@ cdef extern from "zran.h":
         uint8_t  *data;
 
     enum:
-        ZRAN_AUTO_BUILD           =  1,
-        ZRAN_SKIP_CRC_CHECK       =  2,
+        # flags for zran_init
+        ZRAN_AUTO_BUILD     =  1,
+        ZRAN_SKIP_CRC_CHECK =  2,
 
+        # return codes for zran_build_index
+        ZRAN_BUILD_INDEX_OK        =  0,
+        ZRAN_BUILD_INDEX_FAIL      = -1,
+        ZRAN_BUILD_INDEX_CRC_ERROR = -2,
+
+        # return codes for zran_seek
         ZRAN_SEEK_CRC_ERROR       = -2,
         ZRAN_SEEK_FAIL            = -1,
         ZRAN_SEEK_OK              =  0,
@@ -38,14 +45,17 @@ cdef extern from "zran.h":
         ZRAN_SEEK_EOF             =  2,
         ZRAN_SEEK_INDEX_NOT_BUILT =  3,
 
+        # return codes for zran_read
         ZRAN_READ_NOT_COVERED = -1,
         ZRAN_READ_EOF         = -2,
         ZRAN_READ_FAIL        = -3,
         ZRAN_READ_CRC_ERROR   = -4,
 
+        # return codes for zran_export_index
         ZRAN_EXPORT_OK          =  0,
         ZRAN_EXPORT_WRITE_ERROR = -1,
 
+        # return codes for zran_import_index
         ZRAN_IMPORT_OK             =  0,
         ZRAN_IMPORT_FAIL           = -1,
         ZRAN_IMPORT_EOF            = -2,
@@ -55,19 +65,19 @@ cdef extern from "zran.h":
         ZRAN_IMPORT_MEMORY_ERROR   = -6,
         ZRAN_IMPORT_UNKNOWN_FORMAT = -7
 
-    bint zran_init(zran_index_t *index,
-                   FILE         *fd,
-                   PyObject     *f,
-                   uint32_t      spacing,
-                   uint32_t      window_size,
-                   uint32_t      readbuf_size,
-                   uint16_t      flags)
+    int zran_init(zran_index_t *index,
+                  FILE         *fd,
+                  PyObject     *f,
+                  uint32_t      spacing,
+                  uint32_t      window_size,
+                  uint32_t      readbuf_size,
+                  uint16_t      flags)
 
     void zran_free(zran_index_t *index)
 
-    bint zran_build_index(zran_index_t *index,
-                          uint64_t      from_,
-                          uint64_t      until) nogil;
+    int zran_build_index(zran_index_t *index,
+                         uint64_t      from_,
+                         uint64_t      until) nogil;
 
     uint64_t zran_tell(zran_index_t *index);
 

--- a/indexed_gzip/zran.pxd
+++ b/indexed_gzip/zran.pxd
@@ -29,6 +29,7 @@ cdef extern from "zran.h":
 
     enum:
         ZRAN_AUTO_BUILD           =  1,
+        ZRAN_SKIP_CRC_CHECK       =  2,
 
         ZRAN_SEEK_CRC_ERROR       = -2,
         ZRAN_SEEK_FAIL            = -1,

--- a/indexed_gzip/zran.pxd
+++ b/indexed_gzip/zran.pxd
@@ -30,6 +30,7 @@ cdef extern from "zran.h":
     enum:
         ZRAN_AUTO_BUILD           =  1,
 
+        ZRAN_SEEK_CRC_ERROR       = -2,
         ZRAN_SEEK_FAIL            = -1,
         ZRAN_SEEK_OK              =  0,
         ZRAN_SEEK_NOT_COVERED     =  1,
@@ -39,6 +40,7 @@ cdef extern from "zran.h":
         ZRAN_READ_NOT_COVERED = -1,
         ZRAN_READ_EOF         = -2,
         ZRAN_READ_FAIL        = -3,
+        ZRAN_READ_CRC_ERROR   = -4,
 
         ZRAN_EXPORT_OK          =  0,
         ZRAN_EXPORT_WRITE_ERROR = -1,


### PR DESCRIPTION
Closes #69

The `_zran_inflate` function now calculates a CRC32 checksum, and keeps track of the total number of uncompressed bytes in each GZIP stream. When the end of a stream is reached, they are checked against the CRC32/size stored in the gzip stream footer.

The above validation check can be disabled by using the new `ZRAN_SKIP_CRC_CHECK` flag when calling `zran_init`.

As a by-product of the above changes, null padding bytes are now handled correctly. Currently any bytes at the end of a file, or between the end of one GZIP stream and the beginning of another, are ignored. This might be made more strict in the future by only allowing null bytes (i.e. with a value of `00`). 

Some of the unit tests written by @epicfaace in #70 - thanks!