### PR TITLE
Update to index file format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 
 
 * Python 2.7 wheels for Windows are no longer being built (#71, 73).
+* A backwards-compatible change to the index file format, to accommodate seek
+  points at stream boundaries. Index files created with older versions of
+  `indexed_gzip` can still be loaded, but index files created with
+  `indexed_gzip` 1.6.0 cannot be loaded by older versions of `indexed_gzip`
+  (#75).
 
 
 ## 1.5.3 (March 23rd 2021)

--- a/indexed_gzip/tests/ctest_zran.pyx
+++ b/indexed_gzip/tests/ctest_zran.pyx
@@ -1080,12 +1080,9 @@ def test_export_then_import(testfile, no_fds):
             assert p2.cmp_offset   == p1.cmp_offset, msg
             assert p2.uncmp_offset == p1.uncmp_offset, msg
             assert p2.bits         == p1.bits, msg
-            if i == 0:
-                assert not p2.data, msg
-                assert not p1.data, msg
+            if (not p1.data):
+                assert p1.data == p2.data, msg
             else:
-                assert p2.data, msg
-                assert p1.data, msg
                 assert not memcmp(p2.data, p1.data, ws), msg
 
         zran.zran_free(&index1)

--- a/indexed_gzip/tests/test_zran.py
+++ b/indexed_gzip/tests/test_zran.py
@@ -118,3 +118,6 @@ if not sys.platform.startswith("win"):
     def test_export_import_no_points():
         for no_fds in (True, False):
             ctest_zran.test_export_import_no_points(no_fds)
+
+    def test_export_import_format_v0():
+        ctest_zran.test_export_import_format_v0()

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -71,8 +71,13 @@ static double round(double val)
 #define zran_log(...)
 #endif
 
-/* Define magic bytes and version for export format. */
-const char zran_magic_bytes[] = {'G', 'Z', 'I', 'D', 'X', 0, 0};
+
+/*
+ * Identifier and version number for index files created by zran_export_index.
+ */
+const char    ZRAN_INDEX_FILE_ID[]    = {'G', 'Z', 'I', 'D', 'X'};
+const uint8_t ZRAN_INDEX_FILE_VERSION = 1;
+
 
 /*
  * Discards all points in the index which come after the specfiied

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -2578,12 +2578,12 @@ int zran_export_index(zran_index_t *index,
         if (f_ret != 1)     goto fail;
 
         /* Write data flag, and check for errors. */
-        flags = (point->data == NULL) ? 1 : 0;
+        flags = (point->data != NULL) ? 1 : 0;
         f_ret = fwrite_(&flags, 1, 1, fd, f);
         if (ferror_(fd, f)) goto fail;
         if (f_ret != 1)     goto fail;
 
-        zran_log("zran_export_index: (%lu, %lu, %lu, %u, %u)\n",
+        zran_log("zran_export_index: (p%lu, %lu, %lu, %u, %u)\n",
                  (index->npoints - (list_end - point)), // point index
                  point->cmp_offset,
                  point->uncmp_offset,
@@ -2830,23 +2830,24 @@ int zran_import_index(zran_index_t *index,
              * to indicate to the loop below that this point has data
              * to be loaded.
              */
-            if (flags == 0) { point->data = NULL;     }
-            else            { point->data = NULL + 1; }
         }
         /*
          * In index file version 0, the first point
          * has no data, but all other points do.
          */
         else {
-            if (point == new_list) { point->data = NULL;     }
-            else                   { point->data = NULL + 1; }
+            flags = (point == new_list) ? 0 : 1;
         }
 
-        zran_log("zran_import_index: (%lu, %lu, %lu, %u)\n",
+        if (flags == 0) { point->data = NULL;     }
+        else            { point->data = NULL + 1; }
+
+        zran_log("zran_import_index: (p%lu, %lu, %lu, %u, %u)\n",
                  (npoints - (list_end - point)), // point index
                  point->cmp_offset,
                  point->uncmp_offset,
-                 point->bits);
+                 point->bits,
+                 flags);
 
         /* Done with this point. Proceed to the next one. */
         point++;


### PR DESCRIPTION
In #72, index points are now created at stream boundaries, for files containing concatenated GZIP streams. This PR updates the index file format, used by `zran_export_index` and `zran_import_index`, to support index points that do not have any window data associated with them.

The change is backwards-compatible `indexed_gzip` will continue to work with existing index files. But old versions of `indexed_gzip` will not be able to load index files created with a newer version.