### PR TITLE
TEST: handle missing nibabel gracefully

### DIFF
--- a/indexed_gzip/tests/test_nibabel_integration.py
+++ b/indexed_gzip/tests/test_nibabel_integration.py
@@ -7,7 +7,8 @@ import shutil
 
 import pytest
 
-import nibabel      as nib
+nib = pytest.importorskip("nibabel")
+
 import numpy        as np
 import indexed_gzip as igzip
 


### PR DESCRIPTION
Prevent the test suite from failing to load when nibabel is not
available on the system.