### PR TITLE
Bf/memleak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,21 @@
 # `indexed_gzip` changelog
 
+## 1.6.2 (September 2nd 2021)
+
+
+* Fixed a memory leak when initialising decompression / inflation (#82, #83).
+
 
 ## 1.6.1 (May 25th 2021)
 
 
-* Tests requiring `nibabel` are now skipped, rather than causing failure.
+* Tests requiring `nibabel` are now skipped, rather than causing failure (#78).
 
 
 ## 1.6.0 (May 23rd 2021)
 
 
-* Python 2.7 wheels for Windows are no longer being built (#71, 73).
+* Python 2.7 wheels for Windows are no longer being built (#71, #73).
 * A backwards-compatible change to the index file format, to accommodate seek
   points at stream boundaries. Index files created with older versions of
   `indexed_gzip` can still be loaded, but index files created with

--- a/indexed_gzip/tests/test_zran.py
+++ b/indexed_gzip/tests/test_zran.py
@@ -127,3 +127,6 @@ if not sys.platform.startswith("win"):
 
     def test_standard_usage_with_null_padding(concat):
         ctest_zran.test_standard_usage_with_null_padding(concat)
+
+    def test_inflateInit_leak_on_error():
+        ctest_zran.test_inflateInit_leak_on_error()

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -763,7 +763,13 @@ void zran_free(zran_index_t *index) {
     for (i = 0; i < index->npoints; i++) {
         pt = &(index->list[i]);
 
-        free(pt->data);
+        /*
+         * points at compression stream boundaries
+         * have no data associated with them
+         */
+        if (pt->data != NULL) {
+            free(pt->data);
+        }
     }
 
     free(index->list);

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1212,8 +1212,11 @@ int _zran_init_zlib_inflate(zran_index_t *index,
         zran_log("_zran_init_zlib_inflate from current "
                  "seek location (expecting GZIP header)\n");
         if (inflateInit2(stream, windowBits + 32) != Z_OK) { goto fail; }
-        if (inflate(stream, Z_BLOCK)              != Z_OK) { goto fail; }
+        ret = inflate(stream, Z_BLOCK);
         if (inflateEnd(stream)                    != Z_OK) { goto fail; }
+        if (ret != Z_OK) {
+            goto fail;
+        }
     }
 
     /*


### PR DESCRIPTION
See #82 - extends that PR to handle potential leak after the second call to `inflateInit2`