### PR TITLE
MNT: Add pyproject.toml to enable build isolation and build dependency fetching

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools >= 40.8.0", "wheel", "cython"]


### PR DESCRIPTION
Currently if I try `pip install .` or `python -m build`, it will fail with 

```
building 'indexed_gzip.indexed_gzip' extension
creating build/temp.linux-x86_64-cpython-38
creating build/temp.linux-x86_64-cpython-38/indexed_gzip
gcc -pthread -B /home/chris/miniconda3/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -Iindexed_gzip -I/tmp/build-env-df2thqpb/include -I/home/chris/miniconda3/include/python3.8 -c indexed_gzip/indexed_gzip.c -o build/temp.linux-x86_64-cpython-38/indexed_gzip/indexed_gzip.o -Wall -Wno-unused-function
gcc: error: indexed_gzip/indexed_gzip.c: No such file or directory
error: command '/usr/bin/gcc' failed with exit code 1

ERROR Backend subproccess exited when trying to invoke build_wheel
```

Adding cython to the declared build dependencies in `pyproject.toml` allows it to be automatically installed. This should make it so that tests on new versions of Python that you haven't built wheels for can still proceed as long as there's a C compiler, and you publishing wheels will just speed up the process for others.