### PR TITLE
MNT: remove redundant `wheel` dep from pyproject.toml

### DIFF
--- a/.ci/run_tests.sh
+++ b/.ci/run_tests.sh
@@ -24,7 +24,7 @@ if [[ -n "$NELEMS" ]]; then
 fi
 
 python -m indexed_gzip.tests      \
-       -c setup.cfg               \
+       -c pyproject.toml          \
        -v -s                      \
        -m "$TEST_SUITE"           \
        -k "$TEST_PATTERN"         \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 40.8.0", "wheel", "cython", "numpy"]
+requires = ["setuptools >= 40.8.0", "cython", "numpy"]
 
 [tool.pytest.ini_options]
 testpaths = ["indexed_gzip/tests"]


### PR DESCRIPTION
Remove the redundant `wheel` dependency from `pyproject.toml`.  This
dependency was never really necessary, and the setuptools documentation
recommends against adding it as it is an implementation detail.