### PR TITLE
Support unseekable streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # `indexed_gzip` changelog
 
 
-## 1.7.0 (September 10th 2022)
+## 1.7.0 (September 12th 2022)
 
 
 * Changes to allow an index to be built from file-likes which don't support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # `indexed_gzip` changelog
 
 
-## 1.7.0 (September 9th 2022)
+## 1.7.0 (September 10th 2022)
 
 
 * Changes to allow an index to be built from file-likes which don't support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # `indexed_gzip` changelog
 
 
+## 1.7.0 (September 9th 2022)
+
+
+* Changes to allow an index to be built from file-likes which don't support
+  `seek()` or `tell()` operations (#103, #104).
+
+
 ## 1.6.13 (April 14th 2022)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 
 * Changes to allow an index to be built from file-likes which don't support
-  `seek()` or `tell()` operations (#103, #104).
+  `seek()` or `tell()` operations (#103, #105).
 
 
 ## 1.6.13 (April 14th 2022)

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -19,4 +19,4 @@ versions of ``nibabel``.
 """
 
 
-__version__ = '1.6.13'
+__version__ = '1.7.0'

--- a/indexed_gzip/tests/__init__.py
+++ b/indexed_gzip/tests/__init__.py
@@ -40,7 +40,7 @@ def tempdir():
 
 
 def touch(path):
-    """Create an enpty file."""
+    """Create an empty file."""
     with open(path, 'wt') as f:
         pass
 

--- a/indexed_gzip/tests/__init__.py
+++ b/indexed_gzip/tests/__init__.py
@@ -39,6 +39,11 @@ def tempdir():
     return ctx()
 
 
+def touch(path):
+    """Create an enpty file."""
+    with open(path, 'wt') as f:
+        pass
+
 
 def poll(until):
     """Waits until ``until`` returns ``True``, printing out a message every

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -926,7 +926,6 @@ def test_build_index_from_unseekable():
         # then using the index when file is seekable.
         with open(fname, 'rb') as f:
             b = f.read()
-            nbytes = len(b)
             fileobj = BytesIO(b)
 
         def new_seek(*args, **kwargs):

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -25,7 +25,7 @@ import                    tempfile
 import                    contextlib
 
 import numpy as np
-from io import BytesIO, UnsupportedOperation
+from io import BytesIO
 import pytest
 
 import indexed_gzip as igzip

--- a/indexed_gzip/tests/ctest_zran.pyx
+++ b/indexed_gzip/tests/ctest_zran.pyx
@@ -369,6 +369,14 @@ def test_getc():
         PyErr_Clear()
 
 
+def test_seekable():
+
+    f = BytesIO(b"abc")
+    assert zran_file_util._seekable_python(<PyObject*>f) == 1
+    f.seekable = lambda: False
+    assert zran_file_util._seekable_python(<PyObject*>f) == 0
+
+
 def test_init(testfile, no_fds):
     """Tests a bunch of permutations of the parameters to zran_init. """
 

--- a/indexed_gzip/tests/test_indexed_gzip.py
+++ b/indexed_gzip/tests/test_indexed_gzip.py
@@ -160,6 +160,12 @@ def test_get_index_seek_points():
 def test_import_export_index():
     ctest_indexed_gzip.test_import_export_index()
 
+def test_import_export_index_open_file():
+    ctest_indexed_gzip.test_import_export_index_open_file()
+
+def test_build_index_from_unseekable():
+    ctest_indexed_gzip.test_build_index_from_unseekable()
+
 def test_wrapper_class():
     ctest_indexed_gzip.test_wrapper_class()
 

--- a/indexed_gzip/tests/test_zran.py
+++ b/indexed_gzip/tests/test_zran.py
@@ -43,6 +43,9 @@ if not sys.platform.startswith("win"):
     def test_getc():
         ctest_zran.test_getc()
 
+    def test_seekable():
+        ctest_zran.test_seekable()
+
     def test_init(testfile):
         for no_fds in (True, False):
             ctest_zran.test_init(testfile, no_fds)

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -1366,9 +1366,8 @@ static int _zran_read_data_from_file(zran_index_t *index,
         memmove(index->readbuf, stream->next_in, stream->avail_in);
     }
 
-    zran_log("Reading from file %llu [== %llu?] "
+    zran_log("Reading from file %llu "
              "[into readbuf offset %u]\n",
-             ftell_(index->fd, index->f),
              cmp_offset + stream->avail_in,
              stream->avail_in);
 
@@ -1419,7 +1418,7 @@ static int _zran_read_data_from_file(zran_index_t *index,
             if (index->compressed_size == 0) {
                 zran_log("Updating compressed data "
                          "size: %llu\n", cmp_offset);
-                index->compressed_size = cmp_offset;
+                index->compressed_size = cmp_offset + 8;
             }
             goto eof;
         }
@@ -1794,8 +1793,10 @@ static int _zran_inflate(zran_index_t *index,
          * to the correct location in the file for us.
          */
         if (start == NULL) {
-            if (fseek_(index->fd, index->f, 0, SEEK_SET) != 0) {
-                goto fail;
+            if (seekable_(index->fd, index->f)) {
+                if (fseek_(index->fd, index->f, 0, SEEK_SET) != 0) {
+                    goto fail;
+                }
             }
 
             /*

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -657,7 +657,12 @@ int zran_init(zran_index_t *index,
         if (fseek_(fd, f, 0, SEEK_SET) != 0)
             goto fail;
     } else {
-        // File is not seekable, so don't calculate compressed_size.
+        /*
+         * File is not seekable, so don't calculate
+         * compressed_size.  It will be updated in
+         * _zran_read_data_from_file when the EOF
+         * is reached
+         */
         compressed_size = 0;
     }
 

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -276,7 +276,7 @@ int ZRAN_EXPAND_INDEX_CRC_ERROR = -2;
 static int _zran_expand_index(
     zran_index_t *index, /* The index */
     uint64_t      until  /* Expand the index to this point. If 0,
-                            expand  the index until EOF is reached. */
+                            expand the index until EOF is reached. */
 );
 
 
@@ -858,7 +858,7 @@ int _zran_get_point_at(
 
     /*
      * Bad input - past the end of the compressed or
-     * uncompressed streams (if the latter is known).
+     * uncompressed streams (if their sizes are known).
      */
     if (compressed                 &&
         index->compressed_size > 0 &&
@@ -1798,6 +1798,11 @@ static int _zran_inflate(zran_index_t *index,
          * to the correct location in the file for us.
          */
         if (start == NULL) {
+            /*
+             * If file is not seekable, assume that
+             * it is positioned at the beginning of
+             * the stream.
+             */
             if (seekable_(index->fd, index->f)) {
                 if (fseek_(index->fd, index->f, 0, SEEK_SET) != 0) {
                     goto fail;

--- a/indexed_gzip/zran.c
+++ b/indexed_gzip/zran.c
@@ -644,16 +644,21 @@ int zran_init(zran_index_t *index,
     /*
      * Calculate the size of the compressed file
      */
-    if (fseek_(fd, f, 0, SEEK_END) != 0)
-        goto fail;
+    if (seekable_(fd, f)) {
+        if (fseek_(fd, f, 0, SEEK_END) != 0)
+            goto fail;
 
-    compressed_size = ftell_(fd, f);
+        compressed_size = ftell_(fd, f);
 
-    if (compressed_size < 0)
-        goto fail;
+        if (compressed_size < 0)
+            goto fail;
 
-    if (fseek_(fd, f, 0, SEEK_SET) != 0)
-        goto fail;
+        if (fseek_(fd, f, 0, SEEK_SET) != 0)
+            goto fail;
+    } else {
+        // File is not seekable, so don't calculate compressed_size.
+        compressed_size = 0;
+    }
 
     /*
      * Allocate some initial space

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -265,7 +265,10 @@ fail:
  * object is unseekable.
  */
 int _seekable_python2(PyObject *f) {
-    return _ftell_python(f) >= 0;
+    int64_t ret;
+    ret =_ftell_python(f);
+    PyErr_Clear();
+    return ret >= 0;
 }
 
 /*

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -351,5 +351,5 @@ int seekable_(FILE *fd, PyObject *f) {
     return fd != NULL ? 1: _seekable_python(f);
     #else
     return fd != NULL ? 1: _seekable_python2(f);
-    # endif
+    #endif
 }

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -258,6 +258,16 @@ fail:
     return -1;
 }
 
+
+/*
+ * Hacky implementation of seekable() for Python 2.
+ * If f.tell() returns an error, assume that the
+ * object is unseekable.
+ */
+int _seekable_python2(PyObject *f) {
+    return _ftell_python(f) >= 0;
+}
+
 /*
  * Calls ferror on fd if specified, otherwise the Python-specific method on f.
  */
@@ -332,5 +342,9 @@ int getc_(FILE *fd, PyObject *f) {
  * If f is specified, calls f.seekable() to see if the Python file object is seekable.
  */
 int seekable_(FILE *fd, PyObject *f) {
+    #if PY_MAJOR_VERSION > 2
     return fd != NULL ? 1: _seekable_python(f);
+    #else
+    return fd != NULL ? 1: _seekable_python2(f);
+    # endif
 }

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -266,7 +266,7 @@ fail:
  */
 int _seekable_python2(PyObject *f) {
     int64_t ret;
-    ret =_ftell_python(f);
+    ret = _ftell_python(f);
     if (ret < 0) {
         PyErr_Clear();
     }

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -267,7 +267,9 @@ fail:
 int _seekable_python2(PyObject *f) {
     int64_t ret;
     ret =_ftell_python(f);
-    PyErr_Clear();
+    if (ret < 0) {
+        PyErr_Clear();
+    }
     return ret >= 0;
 }
 

--- a/indexed_gzip/zran_file_util.h
+++ b/indexed_gzip/zran_file_util.h
@@ -61,6 +61,11 @@ size_t _fwrite_python(const void *ptr, size_t size, size_t nmemb, PyObject *f);
 int _getc_python(PyObject *f);
 
 /*
+ * Calls the .seekable() method on Python file-like objects.
+ */
+int _seekable_python(PyObject *f);
+
+/*
  * Calls ferror on fd if specified, otherwise the Python-specific method on f.
  */
 int ferror_(FILE *fd, PyObject *f);
@@ -101,5 +106,10 @@ size_t fwrite_(
  */
 int getc_(FILE *fd, PyObject *f);
 
+/*
+ * Returns whether the given file is seekable. If fd is specified, assumes it's always seekable.
+ * If f is specified, calls f.seekable() to see if the Python file object is seekable.
+ */
+int seekable_(FILE *fd, PyObject *f);
 
 #endif /* __ZRAN_FILE_UTIL_H__ */

--- a/indexed_gzip/zran_file_util.pxd
+++ b/indexed_gzip/zran_file_util.pxd
@@ -26,6 +26,8 @@ cdef extern from "zran_file_util.h":
     
     int _getc_python(PyObject *f)
 
+    int _seekable_python(PyObject *f)
+
     int ferror_(FILE *fd, PyObject *f)
 
     int fseek_(FILE *fd, PyObject *f, int64_t offset, int whence)
@@ -41,3 +43,5 @@ cdef extern from "zran_file_util.h":
     size_t fwrite_(const void *ptr, size_t size, size_t nmemb, FILE *fd, PyObject *f)
 
     int getc_(FILE *fd, PyObject *f)
+
+    int seekable_(FILE *fd, PyObject *f)


### PR DESCRIPTION
Fixes #102 and incorporates #103. Also adjusts logic in `zran.c` to remove dependence on knowing the size of the compressed stream.