### PR TITLE
CI: Drop python version back down for old nibabel integration tests

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -140,7 +140,7 @@ jobs:
         nibabel: ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "3.0", "3.1", "3.2"]
     env:
       PLATFORM:       ${{ matrix.os }}
-      PYTHON_VERSION: 3.8
+      PYTHON_VERSION: "3.8"
       TEST_SUITE:     nibabel_test
       NIBABEL:        ${{ matrix.nibabel }}
       # earlier versions of nibabel require
@@ -153,7 +153,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.8"
           architecture:   x64
       - name: Create test environment
         run:  bash ./.ci/create_test_env.sh "$ENV_DIR"


### PR DESCRIPTION
Binary wheels do not appear to be available for numpy 1.20 on python 3.10, and I don't want to be compiling numpy in the CI jobs