### PR TITLE
Replace IndexedGzipFile.__reduce__ with IndexedGzipFile.__reduce_ex__

### DIFF
--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -169,8 +169,10 @@ class IndexedGzipFile(io.BufferedReader):
             return self.read(nbytes)
 
 
-    def __reduce__(self):
+    def __reduce_ex__(self, protocol):
         """Used to pickle an ``IndexedGzipFile``.
+
+        :arg protocol:         Pickle protocol version
 
         Returns a tuple containing:
           - a reference to the ``unpickle`` function
@@ -1093,7 +1095,7 @@ def unpickle(state):
     """Create a new ``IndexedGzipFile`` from a pickled state.
 
     :arg state: State of a pickled object, as returned by the
-                ``IndexedGzipFile.__reduce__`` method.
+                ``IndexedGzipFile.__reduce_ex__`` method.
 
     :returns:   A new ``IndexedGzipFile`` object.
     """


### PR DESCRIPTION
Restores “pickle-ability” of `IndexedGzipFile` in Python 3.12, which was broken due to https://github.com/python/cpython/pull/101948.

Maybe there is a better way to do this – there are a lot of complex possibilities in https://docs.python.org/3.12/library/pickle.html – but simply renaming the method to give it priority over `io.BufferedReader.__reduce_ex__`, and ignoring the new `protocol` parameter, is sufficient to get the tests to pass (without `nibabel` for now) in Fedora Linux Rawhide.