### PR TITLE
Mnt/py37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # `indexed_gzip` changelog
 
 
+## 1.8.1 (July 25th 2023)
+
+
+* Now building packages for python >=3.7, as recent versions of setuptools do
+  not support older Python versions (#133).
+
+
 ## 1.8.0 (July 24th 2023)
 
 

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -19,4 +19,4 @@ versions of ``nibabel``.
 """
 
 
-__version__ = '1.8.0'
+__version__ = '1.8.1'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic         = ["version"]
 description     = "Fast random access of gzip files in Python"
 readme          = {file = "README.md", content-type="text/markdown"}
 license         = {text = "zlib"}
-requires-python = ">=3"
+requires-python = ">=3.7"
 maintainers     = [{name = "Paul McCarthy", email = "pauldmccarthy@gmail.com"}]
 classifiers     = [
     "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Setuptools no longer supports python < 3.7, so with the move to using `pyproject.toml` this is now the minimum Python version that I am willing to support. The code will still build against older Python versions, but this would require having to move back to a `setup.py`/`setup.cfg`-based configuration. Having to spend a full day debugging new problems that arise whenever there is a new version of Python/Cython/whatever brings me great joy.