### PR TITLE
MNT: Raise FileNotFoundError on non-existent path

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,13 +1,13 @@
 # This workflow runs the full set of of indexed_gzip
 # unit tests on a range of different versions of Python,
 # and on different operating systems and architectures.
-# It is run on pushes to the master branch.
+# It is run on pushes to the main branch.
 
 
 on:
   push:
     branches:
-      - master
+      - main
 
 
 defaults:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # `indexed_gzip` changelog
 
 
+## 1.8.4 (August 30th 2023)
+
+
+* Change the `IndexedGzipFile` class to raise a `FileNotFoundError` instead
+  of a `ValueError`, when a path to a non-existent file is provided (#137).
+
+
 ## 1.8.3 (July 25th 2023)
 
 
 * Another adjustment to package build process (#135).
-
 
 
 ## 1.8.2 (July 25th 2023)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # indexed_gzip
 
 
-[![PyPi version](https://img.shields.io/pypi/v/indexed_gzip.svg)](https://pypi.python.org/pypi/indexed_gzip/) [![Anaconda version](https://anaconda.org/conda-forge/indexed_gzip/badges/version.svg)](https://anaconda.org/conda-forge/indexed_gzip/)![Test status](https://github.com/pauldmccarthy/indexed_gzip/actions/workflows/master.yaml/badge.svg)
+[![PyPi version](https://img.shields.io/pypi/v/indexed_gzip.svg)](https://pypi.python.org/pypi/indexed_gzip/) [![Anaconda version](https://anaconda.org/conda-forge/indexed_gzip/badges/version.svg)](https://anaconda.org/conda-forge/indexed_gzip/)![Test status](https://github.com/pauldmccarthy/indexed_gzip/actions/workflows/main.yaml/badge.svg)
 
 
  *Fast random access of gzip files in Python*

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -19,4 +19,4 @@ versions of ``nibabel``.
 """
 
 
-__version__ = '1.8.3'
+__version__ = '1.8.4'

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -372,7 +372,7 @@ cdef class _IndexedGzipFile:
         # a segmentation fault on linux. So
         # let's check before that happens.
         if (filename is not None) and (not op.isfile(filename)):
-            raise FileNotFoundError(f'File {filename} does not exist')
+            raise DoesNotExistError(f'File {filename} does not exist')
 
         mode     = 'rb'
         own_file = fileobj is None
@@ -1116,14 +1116,12 @@ class NotCoveredError(ValueError):
     this error will only occur on attempts to call the ``seek`` method
     with ``whence=SEEK_END``, where the index has not been completely built.
     """
-    pass
 
 
 class ZranError(IOError):
     """Exception raised by the :class:`_IndexedGzipFile` when the ``zran``
     library signals an error.
     """
-    pass
 
 
 class CrcError(OSError):
@@ -1131,13 +1129,18 @@ class CrcError(OSError):
     validation check fails, which suggests that the GZIP data might be
     corrupt.
     """
-    pass
 
 
 class NoHandleError(ValueError):
     """Exception raised by the :class:`_IndexedGzipFile` when
     ``drop_handles is True`` and an attempt is made to access the underlying
     file object.
+    """
+
+
+class DoesNotExistError(ValueError, FileNotFoundError):
+    """Exception raised by the :class:`_IndexedGzipFile` when it is passed
+    a path to a file that does not exist.
     """
 
 

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -364,8 +364,7 @@ cdef class _IndexedGzipFile:
                              'in read-only binary ("rb") mode')
 
         if (fileobj is None) and (mode not in (None, 'r', 'rb')):
-            raise ValueError('Invalid mode ({}), must be '
-                             '"r" or "rb"'.format(mode))
+            raise ValueError(f'Invalid mode ({mode}), must be "r" or "rb"')
 
         # If __file_handle is called on a file
         # that doesn't exist, it passes the
@@ -373,7 +372,7 @@ cdef class _IndexedGzipFile:
         # a segmentation fault on linux. So
         # let's check before that happens.
         if (filename is not None) and (not op.isfile(filename)):
-            raise ValueError('File {} does not exist'.format(filename))
+            raise FileNotFoundError(f'File {filename} does not exist')
 
         mode     = 'rb'
         own_file = fileobj is None
@@ -427,8 +426,8 @@ cdef class _IndexedGzipFile:
                               window_size=window_size,
                               readbuf_size=readbuf_size,
                               flags=flags):
-                raise ZranError('zran_init returned error (file: '
-                                '{})'.format(self.errname))
+                raise ZranError('zran_init returned error '
+                                f'(file: {self.errname})')
 
         log.debug('%s.__init__(%s, %s, %s, %s, %s, %s, %s)',
                   type(self).__name__,
@@ -546,8 +545,8 @@ cdef class _IndexedGzipFile:
         """Closes this ``_IndexedGzipFile``. """
 
         if self.closed:
-            raise IOError('_IndexedGzipFile is already closed '
-                          '(file: {})'.format(self.errname))
+            raise IOError('_IndexedGzipFile is already '
+                          f'closed (file: {self.errname})')
 
         if   self.own_file and self.pyfid    is not None: self.pyfid.close()
         elif self.own_file and self.index.fd is not NULL: fclose(self.index.fd)
@@ -655,23 +654,22 @@ cdef class _IndexedGzipFile:
         cdef zran.zran_index_t *index    = &self.index
 
         if whence not in (SEEK_SET, SEEK_CUR, SEEK_END):
-            raise ValueError('Invalid value for whence: {}'.format(whence))
+            raise ValueError(f'Invalid value for whence: {whence}')
 
         with self.__file_handle(), nogil:
             ret = zran.zran_seek(index, off, c_whence, NULL)
 
         if ret == zran.ZRAN_SEEK_NOT_COVERED:
             raise NotCoveredError('Index does not cover '
-                                  'offset {}'.format(offset))
+                                  f'offset {offset}')
 
         elif ret == zran.ZRAN_SEEK_INDEX_NOT_BUILT:
             raise NotCoveredError('Index must be completely built '
                                   'in order to seek from SEEK_END')
 
         elif ret == zran.ZRAN_SEEK_CRC_ERROR:
-            raise CrcError('CRC/size validation failed - the '
-                           'GZIP data might be corrupt (file: '
-                           '{})'.format(self.errname))
+            raise CrcError('CRC/size validation failed - the GZIP data '
+                           f'might be corrupt (file: {self.errname})')
 
         elif ret not in (zran.ZRAN_SEEK_OK, zran.ZRAN_SEEK_EOF):
             raise ZranError('zran_seek returned error: {} (file: {})'
@@ -736,9 +734,8 @@ cdef class _IndexedGzipFile:
                 # CRC or size check failed - data
                 # might be corrupt
                 elif ret == zran.ZRAN_READ_CRC_ERROR:
-                    raise CrcError('CRC/size validation failed - the '
-                                   'GZIP data might be corrupt (file: '
-                                   '{})'.format(self.errname))
+                    raise CrcError('CRC/size validation failed - the GZIP data '
+                                   f'might be corrupt (file: {self.errname})')
 
 
                 # Unknown error

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -364,7 +364,8 @@ cdef class _IndexedGzipFile:
                              'in read-only binary ("rb") mode')
 
         if (fileobj is None) and (mode not in (None, 'r', 'rb')):
-            raise ValueError(f'Invalid mode ({mode}), must be "r" or "rb"')
+            raise ValueError('Invalid mode ({}), must be '
+                             '"r" or "rb"'.format(mode))
 
         # If __file_handle is called on a file
         # that doesn't exist, it passes the
@@ -372,7 +373,7 @@ cdef class _IndexedGzipFile:
         # a segmentation fault on linux. So
         # let's check before that happens.
         if (filename is not None) and (not op.isfile(filename)):
-            raise DoesNotExistError(f'File {filename} does not exist')
+            raise DoesNotExistError('File {} does not exist'.format(filename))
 
         mode     = 'rb'
         own_file = fileobj is None
@@ -426,8 +427,8 @@ cdef class _IndexedGzipFile:
                               window_size=window_size,
                               readbuf_size=readbuf_size,
                               flags=flags):
-                raise ZranError('zran_init returned error '
-                                f'(file: {self.errname})')
+                raise ZranError('zran_init returned error (file: '
+                                '{})'.format(self.errname))
 
         log.debug('%s.__init__(%s, %s, %s, %s, %s, %s, %s)',
                   type(self).__name__,
@@ -545,8 +546,8 @@ cdef class _IndexedGzipFile:
         """Closes this ``_IndexedGzipFile``. """
 
         if self.closed:
-            raise IOError('_IndexedGzipFile is already '
-                          f'closed (file: {self.errname})')
+            raise IOError('_IndexedGzipFile is already closed '
+                          '(file: {})'.format(self.errname))
 
         if   self.own_file and self.pyfid    is not None: self.pyfid.close()
         elif self.own_file and self.index.fd is not NULL: fclose(self.index.fd)
@@ -654,22 +655,23 @@ cdef class _IndexedGzipFile:
         cdef zran.zran_index_t *index    = &self.index
 
         if whence not in (SEEK_SET, SEEK_CUR, SEEK_END):
-            raise ValueError(f'Invalid value for whence: {whence}')
+            raise ValueError('Invalid value for whence: {}'.format(whence))
 
         with self.__file_handle(), nogil:
             ret = zran.zran_seek(index, off, c_whence, NULL)
 
         if ret == zran.ZRAN_SEEK_NOT_COVERED:
             raise NotCoveredError('Index does not cover '
-                                  f'offset {offset}')
+                                  'offset {}'.format(offset))
 
         elif ret == zran.ZRAN_SEEK_INDEX_NOT_BUILT:
             raise NotCoveredError('Index must be completely built '
                                   'in order to seek from SEEK_END')
 
         elif ret == zran.ZRAN_SEEK_CRC_ERROR:
-            raise CrcError('CRC/size validation failed - the GZIP data '
-                           f'might be corrupt (file: {self.errname})')
+            raise CrcError('CRC/size validation failed - the '
+                           'GZIP data might be corrupt (file: '
+                           '{})'.format(self.errname))
 
         elif ret not in (zran.ZRAN_SEEK_OK, zran.ZRAN_SEEK_EOF):
             raise ZranError('zran_seek returned error: {} (file: {})'
@@ -734,8 +736,9 @@ cdef class _IndexedGzipFile:
                 # CRC or size check failed - data
                 # might be corrupt
                 elif ret == zran.ZRAN_READ_CRC_ERROR:
-                    raise CrcError('CRC/size validation failed - the GZIP data '
-                                   f'might be corrupt (file: {self.errname})')
+                    raise CrcError('CRC/size validation failed - the '
+                                   'GZIP data might be corrupt (file: '
+                                   '{})'.format(self.errname))
 
 
                 # Unknown error

--- a/indexed_gzip/tests/ctest_indexed_gzip.pyx
+++ b/indexed_gzip/tests/ctest_indexed_gzip.pyx
@@ -218,6 +218,11 @@ def test_init_failure_cases(concat, drop):
         with pytest.raises(ValueError):
             f = igzip._IndexedGzipFile(drop_handles=drop)
 
+        # Doesn't exist
+        with pytest.raises(FileNotFoundError):
+            f = igzip._IndexedGzipFile(filename='no_file.gz',
+                                       drop_handles=drop)
+
         # can only specify one of filename/fid
         with pytest.raises(ValueError):
             with open(testfile, mode='rb'):


### PR DESCRIPTION
Update the `IndexedGzipFile` class to raise a `FileNotFoundError` rather than a `ValueError`, when passed a path to a non-existent file. This change is made to improve consistency with the `gzip.GzipFile` class.

To preserve compatibility, a custom error type is raised - this type sub-classes both `FileNotFoundError` and `ValueError`.