### PR TITLE
Ci/py312

### DIFF
--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -22,7 +22,9 @@ export CIBW_TEST_REQUIRES="cython pytest numpy nibabel coverage cython-coverage 
 #
 # Disable musllinux builds until numpy binaries are available (as
 # compiling numpy takes too long, and causes GHA jobs to time out).
-export CIBW_SKIP="pp* *musllinux*"
+#
+# Disable py312 builds until numpy is available
+export CIBW_SKIP="pp* *musllinux* *312*"
 
 # Skip i686/aarch64 tests - I have experienced hangs on these
 # platforms, which I traced to a trivial numpy operation -

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # `indexed_gzip` changelog
 
 
-## 1.8.4 (August 30th 2023)
+## 1.8.5 (August 29th 2023)
+
+
+*  Updates to package build process (#138).
+
+
+## 1.8.4 (August 29th 2023)
 
 
 * Change the `IndexedGzipFile` class to raise a `FileNotFoundError` instead

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -19,4 +19,4 @@ versions of ``nibabel``.
 """
 
 
-__version__ = '1.8.4'
+__version__ = '1.8.5'


### PR DESCRIPTION
Disable building for Python 3.12 until upstream problems with numpy/setuptools/whatever are resolved