### PR TITLE
Minor adjustments to exception handling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Build sdist
         run:  python setup.py sdist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.4.3
         with:
           name: sdist
           path: ./dist/*.tar.gz
@@ -49,7 +49,7 @@ jobs:
       - name: Build wheels
         run:  bash ./.ci/build_wheels.sh
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.4.3
         with:
           name: wheels
           path: ./dist/*.whl
@@ -76,7 +76,7 @@ jobs:
         run:  bash ./.ci/download_zlib.sh
       - name: Build wheels
         run:  bash ./.ci/build_wheels.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.4.3
         with:
           name: wheels
           path: ./dist/*.whl
@@ -105,7 +105,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Build wheels
         run:  bash ./.ci/build_wheels.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4.4.3
         with:
           name: wheels
           path: ./dist/*.whl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # `indexed_gzip` changelog
 
 
+## 1.9.0 (November 15th 2024)
+
+
+* Preserve exception information when reading from a Python file-like (#152).
+
+
 ## 1.8.8 (November 7th 2024)
 
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ Many thanks to the following contributors (listed chronologically):
  - Maximilian Knespel (@mxmlnkn) Change default read buffer size to
    improve performance (#90).
  - Ben Beasley (@musicinmybrain) Python 3.12 compatibility (#126).
+ - @camillol: Preserve exceptions raised by Python file-likes (#152).
 
 
 ## License

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -19,4 +19,4 @@ versions of ``nibabel``.
 """
 
 
-__version__ = '1.8.8'
+__version__ = '1.9.0'

--- a/indexed_gzip/set_traceback.pxd
+++ b/indexed_gzip/set_traceback.pxd
@@ -1,0 +1,10 @@
+#
+# Cython declaration for the PyException_SetTraceback function.
+# This function is in the Python C API, but is not in the built-in
+# Cython declarations.
+#
+
+from cpython.ref cimport PyObject
+
+cdef extern from "Python.h":
+    PyObject* PyException_SetTraceback(PyObject* ex, PyObject* tb)


### PR DESCRIPTION
We can use `PyException_SetTraceback` to preserve the traceback from the underlying exception.

Also change the `upload-artifact` action version to hopefully resolve non-sensical errors about duplicate artifacts