### PR TITLE
Add Python 3.13t (free-threaded) builds

### DIFF
--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -44,6 +44,9 @@ export CIBW_SKIP="pp*"
 #
 export CIBW_TEST_SKIP="*i686* *aarch64* cp312-win* cp313-win*"
 
+# Enable free-threaded builds for Python versions (3.13t) that support it
+export CIBW_FREE_THREADED_SUPPORT=1
+
 # Pytest makes it *very* awkward to run tests
 # from an installed package, and still find/
 # interpret a conftest.py file correctly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 ## 1.9.2 (November 18th 2024)
 
 
-* Adjustment to exception handling (#158).
+* Enable builds for free-threading Python versions (#157).
+* Adjustment to exception handling (#159).
 
 
 ## 1.9.1 (November 15th 2024)

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -19,4 +19,4 @@ versions of ``nibabel``.
 """
 
 
-__version__ = '1.9.1'
+__version__ = '1.9.2'

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -1,4 +1,4 @@
-# cython: binding=True,embedsignature=True
+# cython: binding=True,embedsignature=True,freethreading_compatible=True
 #
 # The IndexedGzipFile class.
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires      = ["setuptools >= 40.8.0", "cython"]
+requires      = ["setuptools >= 40.8.0", "cython >= 3.1.0a1"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
The Cython alpha release hit PyPI a couple days ago. You may prefer to wait until there's a stable build, but in case you're interested, the tests pass locally in the x86_64 linux build.

If you're up for this, would you also want a full test suite in `main.yaml`/`pull_request.yaml`? We could install a free-threaded build with conda, deadsnakes or uv.