### PR TITLE
MNT: Call `PyErr_Restore` to clear error state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # `indexed_gzip` changelog
 
 
+## 1.9.2 (November 18th 2024)
+
+
+* Adjustment to exception handling (#158).
+
+
 ## 1.9.1 (November 15th 2024)
 
 

--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -34,7 +34,7 @@ from cpython.buffer             cimport (PyObject_GetBuffer,
 from cpython.ref                cimport (PyObject,
                                          Py_XDECREF)
 from cpython.exc                cimport (PyErr_Fetch,
-                                         PyErr_Fetch,
+                                         PyErr_Restore,
                                          PyErr_NormalizeException,
                                          PyErr_Occurred)
 from indexed_gzip.set_traceback cimport  PyException_SetTraceback
@@ -102,6 +102,7 @@ cdef get_python_exception():
         exc = <object>pvalue
         if PY3 and (ptraceback != NULL):
             PyException_SetTraceback(pvalue, NULL)
+        PyErr_Restore(NULL, NULL, NULL)
         Py_XDECREF(ptype)
         Py_XDECREF(pvalue)
         Py_XDECREF(ptraceback)


### PR DESCRIPTION
Fixes #158 