### PR TITLE
MNT: Drop python 3.7

### DIFF
--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -17,9 +17,12 @@ export CIBW_ENVIRONMENT_WINDOWS="ZLIB_HOME='$ZLIB_HOME'"
 # Run quick test suite on built wheels.
 export CIBW_TEST_REQUIRES="cython pytest numpy nibabel coverage cython-coverage pytest-cov"
 
-# Disable pypy builds (reasons for doing this have been lost to
-# history [GHA logs of failing builds deleted]).
-export CIBW_SKIP="pp*"
+# Disable python 3.7, as it is EOL as of June 2023, and
+# unsupported by cython>=3.1.0
+#
+# Disable pypy builds (reasons for doing this have been
+# lost to history [GHA logs of failing builds deleted]).
+export CIBW_SKIP="cp37* pp*"
 
 # Skip i686 and aarch64 tests:
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Enable builds for free-threading Python versions (#157).
 * Adjustment to exception handling (#159).
+* Remove Python 3.7 builds (#160).
 
 
 ## 1.9.1 (November 15th 2024)

--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ A major advantage of `indexed_gzip` is that it will work with any GZIP file.
 However, if you have control over the creation of your GZIP files, you may
 wish to consider some alternatives:
 
+ * [`rapidgzip`](https://github.com/mxmlnkn/rapidgzip/) is an accelerated
+   GZIP decompression library which works with any GZIP file.
  * [`mgzip`](https://github.com/vinlyx/mgzip/) provides an accelerated
-   GZIP compression and decompression library.
+   GZIP compression and decompression library; in order to obtain improved
+   performance you must create your files with `mgzip`.
  * Compression formats other than GZIP, such as `bzip2` and `xz`, have better
    support for random access.
 


### PR DESCRIPTION
Cython >= 3.1.0 does not support Python 3.7, which was EOLed in June 2023