### PR TITLE
Fix exception propagation in readinto

### DIFF
--- a/indexed_gzip/indexed_gzip.pyx
+++ b/indexed_gzip/indexed_gzip.pyx
@@ -835,8 +835,10 @@ cdef class _IndexedGzipFile:
         try:
 
             vbuf = <void *>pbuf.buf
-            with self.__file_handle(), nogil:
-                ret = zran.zran_read(index, vbuf, bufsz)
+            with self.__file_handle():
+                with nogil:
+                    ret = zran.zran_read(index, vbuf, bufsz)
+                exc = get_python_exception()
 
         # release the py_buffer
         finally:
@@ -844,7 +846,6 @@ cdef class _IndexedGzipFile:
 
         # see how the read went
         if ret == zran.ZRAN_READ_FAIL:
-            exc = get_python_exception()
             raise ZranError('zran_read returned error: {} (file: {})'
                             .format(ZRAN_ERRORS.ZRAN_READ[ret], self.errname)) from exc
 


### PR DESCRIPTION
Follow-up to https://github.com/pauldmccarthy/indexed_gzip/pull/152. The `readinto` code path did not correctly recover the original exception. This also affected `read` when using `IndexedGzipFile` (the buffered version), which calls `readinto` on `_IndexedGzipFile`.

Expanded test to cover this case.

Also fixes a subtle test breakage introduced in https://github.com/pauldmccarthy/indexed_gzip/pull/153: if you turn `assert condition, message` into `assert (condition, message)`, the condition becomes a tuple and is always true.