### PR TITLE
MNT: Expand exception preservation to more scenarios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # `indexed_gzip` changelog
 
 
+## 1.9.3 (November 27th 2024)
+
+
+* Expanded exception preservation to more scenarios (#161, #162).
+
+
 ## 1.9.2 (November 18th 2024)
 
 

--- a/indexed_gzip/__init__.py
+++ b/indexed_gzip/__init__.py
@@ -19,4 +19,4 @@ versions of ``nibabel``.
 """
 
 
-__version__ = '1.9.2'
+__version__ = '1.9.3'

--- a/indexed_gzip/zran_file_util.c
+++ b/indexed_gzip/zran_file_util.c
@@ -194,7 +194,8 @@ size_t _fwrite_python(const void *ptr,
         goto fail;
     if ((data = PyObject_CallMethod(f, "write", "(O)", input)) == NULL)
         goto fail;
-
+    if (PyErr_Occurred())
+        goto fail;
     #if PY_MAJOR_VERSION >= 3
     if ((len = PyLong_AsLong(data)) == -1 && PyErr_Occurred())
         goto fail;


### PR DESCRIPTION
Use the mechanism from #152 in more scenarios, including:
 - at creation
 - `seek`
 - `build_full_index`
 - `export_index`
 - `import_index`

Also:
 - fixes a subtle bug in `zran_file_util.c:_fwrite_python`, where an exception raised by the file-like `write` method could be absorbed.
 - Attempt to work around unexplainable test failures on Windows+free-threaded Python
 - Remove a workaround for cython<=0.26, where a `cdef` method could not be decorated with `contextlib.contextmanager`