### PR TITLE
Drop 3.13t builds from cibuildwheel configuration

### DIFF
--- a/.ci/build_wheels.sh
+++ b/.ci/build_wheels.sh
@@ -40,9 +40,6 @@ export CIBW_TEST_REQUIRES="cython pytest numpy nibabel coverage pytest-cov"
 #
 export CIBW_TEST_SKIP="*i686* *aarch64* cp312-win* cp313-win* cp313t-win*"
 
-# Enable free-threaded builds for Python versions (3.13t) that support it
-export CIBW_ENABLE=cpython-freethreading
-
 # Pytest makes it *very* awkward to run tests
 # from an installed package, and still find/
 # interpret a conftest.py file correctly.


### PR DESCRIPTION
See the note at https://cibuildwheel.pypa.io/en/stable/changelog/#v341 and https://github.com/pypa/cibuildwheel/pull/2787.

This option will be removed in the next release of cibuildwheel. It is only needed to produce 3.13t wheels, 3.14t and future free-threaded builds will happen without any special configuration.

I'm going through repositories on GitHub that enable this option and sending in PRs to disable it. Happy to answer questions about this.

If you're curious why 3.13t support is going away so soon, see https://py-free-threading.github.io/ci/#building-free-threaded-wheels-with-cibuildwheel for further guidance.